### PR TITLE
Stop filtering out 'ICB COMMISSIONING PROXY' orgs

### DIFF
--- a/openprescribing/data/ingestors/ods.py
+++ b/openprescribing/data/ingestors/ods.py
@@ -41,7 +41,7 @@ def ingest_ods(conn):
     ORG_TYPE_QUERIES = {
         OrgType.REGION: "primaryRoleName = 'NHS ENGLAND (REGION)'",
         OrgType.ICB: "'INTEGRATED CARE BOARD' IN roleName",
-        OrgType.SICBL: "'SUB ICB LOCATION' IN roleName AND 'ICB COMMISSIONING PROXY' NOT IN roleName",
+        OrgType.SICBL: "'SUB ICB LOCATION' IN roleName",
         OrgType.PCN: "primaryRoleName = 'PRIMARY CARE NETWORK'",
         OrgType.PRACTICE: "'GP PRACTICE' IN roleName",
         OrgType.OTHER: "primaryRoleName = 'PRESCRIBING COST CENTRE' AND 'GP PRACTICE' NOT IN roleName",


### PR DESCRIPTION
Some SICBLs have this as an additional role and I erroneously thought this meant we didn't want to include them. It turns out we do.