### PR TITLE
Allow independent config for DATA_DIR and DOWNLOAD_DIR

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,3 +1,4 @@
 DJANGO_DEBUG="True"
 DJANGO_SECRET_KEY="django-insecure-_)wr$24j5r(iqyloz8i1@uo$h+bqxw_2(@6#r!f@8dsu^9*+py"
-OPENPRESCRIBING_WORK_DIR="work_dir"
+OPENPRESCRIBING_DATA_DIR="work_dir/data"
+OPENPRESCRIBING_DOWNLOAD_DIR="work_dir/downloads"

--- a/openprescribing/config/settings.py
+++ b/openprescribing/config/settings.py
@@ -43,12 +43,10 @@ def get_env_var(name):
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parents[2]
 
-# Working directory for application state. Note that this is not necessarily relative to
-# BASE_DIR: if OPENPRESCRIBING_WORK_DIR is an absolute path it can point anywhere.
-WORK_DIR = BASE_DIR / get_env_var("OPENPRESCRIBING_WORK_DIR")
-
-DOWNLOAD_DIR = WORK_DIR / "downloads"
-DATA_DIR = WORK_DIR / "data"
+# Directories for application state. Note that these are not necessarily relative to
+# BASE_DIR: if they are absolute paths then they can point anywhere.
+DOWNLOAD_DIR = BASE_DIR / get_env_var("OPENPRESCRIBING_DOWNLOAD_DIR")
+DATA_DIR = BASE_DIR / get_env_var("OPENPRESCRIBING_DATA_DIR")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/


### PR DESCRIPTION
In production we want to point these to different directories backed by different storage devices.

The relevant production config has already been done, but the changes won't take effect until this PR is deployed.

Note that local `.env` files will need replacing with the newly updated `dotenv-sample`.

Closes #27