### PR TITLE
Enforce conventional aliases for imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ exclude = [
 extend-select = [
   "A",  # flake8-builtins
   "I",  # isort
+  "ICN",  # flake8-import-conventions
   "INP",  # flake8-no-pep420
   "ISC",  # flake8-implicit-str-concat
   "UP",  # pyupgrade
@@ -86,6 +87,11 @@ extend-ignore = [
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2
+
+[tool.ruff.lint.flake8-import-conventions.aliases]
+altair = "alt"
+numpy = "np"
+pandas = "pd"
 
 # Note: any `exclude-newer-package` timestamps should be removed if > 7 days old
 # See https://github.com/opensafely-core/repo-template/blob/main/DEVELOPERS.md for details


### PR DESCRIPTION
Ruff will now complain on:

    import numpy

Instead, it requires:

    import numpy as np

Thanks @iaindillingham for the pointer: https://github.com/bennettoxford/openprescribing-v2/pull/94#discussion_r2727777994.