### PR TITLE
Use "part" instead of "slot" or "component"

### DIFF
--- a/openprescribing/data/models/bnf_codes.py
+++ b/openprescribing/data/models/bnf_codes.py
@@ -22,7 +22,7 @@ class BNFCode(models.Model):
     name = models.TextField()
 
     @property
-    def slots(self):
+    def parts(self):
         pattern = r"""
             \A
             (?P<chapter>.{2})
@@ -36,11 +36,11 @@ class BNFCode(models.Model):
             \Z
         """
         match = re.match(pattern, self.code, re.VERBOSE)
-        return Slots(**match.groupdict())
+        return Parts(**match.groupdict())
 
     def is_generic(self):
         assert self.level in [BNFCode.Level.PRODUCT, BNFCode.Level.PRESENTATION]
-        return self.slots.product == "AA"
+        return self.parts.product == "AA"
 
     def is_ancestor_of(self, other):
         return other.code != self.code and other.code.startswith(self.code)
@@ -50,17 +50,17 @@ class BNFCode(models.Model):
         assert other.level == BNFCode.Level.PRESENTATION
         assert self.is_generic()
         return (
-            self.slots.chapter == other.slots.chapter
-            and self.slots.section == other.slots.section
-            and self.slots.paragraph == other.slots.paragraph
-            and self.slots.subparagraph == other.slots.subparagraph
-            and self.slots.chemical_substance == other.slots.chemical_substance
-            and self.slots.strength_and_formulation == other.slots.generic_equivalent
+            self.parts.chapter == other.parts.chapter
+            and self.parts.section == other.parts.section
+            and self.parts.paragraph == other.parts.paragraph
+            and self.parts.subparagraph == other.parts.subparagraph
+            and self.parts.chemical_substance == other.parts.chemical_substance
+            and self.parts.strength_and_formulation == other.parts.generic_equivalent
         )
 
 
 @dataclass
-class Slots:
+class Parts:
     chapter: str | None
     section: str | None
     paragraph: str | None

--- a/openprescribing/data/rxdb/search.py
+++ b/openprescribing/data/rxdb/search.py
@@ -23,10 +23,10 @@ def search(terms, product_type):
       BNF code are matched; or
 
     * a BNF chemical substance code (nine-characters), an underscore, and
-      a strength and formulation component (two-characters). The underscore is a
-      wild card that replaces the product component (two-characters). All
+      a strength and formulation part (two-characters). The underscore is a
+      wild card that replaces the product part (two-characters). All
       BNF presentation codes that are descendants of this BNF chemical substance code,
-      and have this strength and formulation component, are matched. For example,
+      and have this strength and formulation part, are matched. For example,
       "040702040_AM" matches "040702040AAAMAM", which is the BNF presentation code for
       "Tramadol 300mg modified-release tablets".
 
@@ -100,13 +100,13 @@ class StrengthAndFormulationFragment:
         self.negated = negated
 
         # A BNF strength and formulation code has 13 characters. However, we expect
-        # the product component (two characters) to be replaced by an underscore.
+        # the product part (two characters) to be replaced by an underscore.
         assert len(term) == 12
         assert term[9] == "_"
 
         self.prefix, self.suffix = term.split("_")
         assert len(self.prefix) == 9  # chemical substance code
-        assert len(self.suffix) == 2  # strength and formulation component
+        assert len(self.suffix) == 2  # strength and formulation part
 
     def build_q(self):
         return Q(code__startswith=self.prefix, code__endswith=self.suffix)

--- a/tests/data/models/test_bnf_codes.py
+++ b/tests/data/models/test_bnf_codes.py
@@ -1,12 +1,12 @@
 import pytest
 
 from openprescribing.data.models import BNFCode
-from openprescribing.data.models.bnf_codes import Slots
+from openprescribing.data.models.bnf_codes import Parts
 
 
 @pytest.mark.django_db(databases=["data"])
-def test_slots(bnf_codes):
-    assert bnf_code("10").slots == Slots(
+def test_parts(bnf_codes):
+    assert bnf_code("10").parts == Parts(
         chapter="10",
         section=None,
         paragraph=None,
@@ -17,7 +17,7 @@ def test_slots(bnf_codes):
         generic_equivalent=None,
     )
 
-    assert bnf_code("1001030U0BDABAC").slots == Slots(
+    assert bnf_code("1001030U0BDABAC").parts == Parts(
         chapter="10",
         section="01",
         paragraph="03",


### PR DESCRIPTION
We've settled on "part" as the word that describes a chapter, section, paragraph, subparagraph, chemical substance, product, strength and formulation, or generic equivalent substring.