### PR TITLE
Parts dataclass -> Parts namedtuple

### DIFF
--- a/openprescribing/data/models/bnf_codes.py
+++ b/openprescribing/data/models/bnf_codes.py
@@ -1,5 +1,5 @@
+import collections
 import re
-from dataclasses import dataclass
 
 from django.db import models
 
@@ -36,6 +36,7 @@ class BNFCode(models.Model):
             \Z
         """
         match = re.match(pattern, self.code, re.VERBOSE)
+        Parts = collections.namedtuple("Parts", match.groupdict().keys())
         return Parts(**match.groupdict())
 
     def is_generic(self):
@@ -57,15 +58,3 @@ class BNFCode(models.Model):
             and self.parts.chemical_substance == other.parts.chemical_substance
             and self.parts.strength_and_formulation == other.parts.generic_equivalent
         )
-
-
-@dataclass
-class Parts:
-    chapter: str | None
-    section: str | None
-    paragraph: str | None
-    subparagraph: str | None
-    chemical_substance: str | None
-    product: str | None
-    strength_and_formulation: str | None
-    generic_equivalent: str | None

--- a/tests/data/models/test_bnf_codes.py
+++ b/tests/data/models/test_bnf_codes.py
@@ -1,32 +1,29 @@
 import pytest
 
 from openprescribing.data.models import BNFCode
-from openprescribing.data.models.bnf_codes import Parts
 
 
 @pytest.mark.django_db(databases=["data"])
 def test_parts(bnf_codes):
-    assert bnf_code("10").parts == Parts(
-        chapter="10",
-        section=None,
-        paragraph=None,
-        subparagraph=None,
-        chemical_substance=None,
-        product=None,
-        strength_and_formulation=None,
-        generic_equivalent=None,
-    )
+    parts_of_chapter = bnf_code("10").parts
+    assert parts_of_chapter.chapter == "10"
+    assert parts_of_chapter.section is None
+    assert parts_of_chapter.paragraph is None
+    assert parts_of_chapter.subparagraph is None
+    assert parts_of_chapter.chemical_substance is None
+    assert parts_of_chapter.product is None
+    assert parts_of_chapter.strength_and_formulation is None
+    assert parts_of_chapter.generic_equivalent is None
 
-    assert bnf_code("1001030U0BDABAC").parts == Parts(
-        chapter="10",
-        section="01",
-        paragraph="03",
-        subparagraph="0",
-        chemical_substance="U0",
-        product="BD",
-        strength_and_formulation="AB",
-        generic_equivalent="AC",
-    )
+    parts_of_presentation = bnf_code("1001030U0BDABAC").parts
+    assert parts_of_presentation.chapter == "10"
+    assert parts_of_presentation.section == "01"
+    assert parts_of_presentation.paragraph == "03"
+    assert parts_of_presentation.subparagraph == "0"
+    assert parts_of_presentation.chemical_substance == "U0"
+    assert parts_of_presentation.product == "BD"
+    assert parts_of_presentation.strength_and_formulation == "AB"
+    assert parts_of_presentation.generic_equivalent == "AC"
 
 
 @pytest.mark.django_db(databases=["data"])


### PR DESCRIPTION
When the Parts dataclass was introduced in #88 (it was called Slots back then), I asked whether it should be a namedtuple. My reason was that a dataclass introduces type hints, and if type hints aren't checked, then they can drift. Ultimately, my reason wasn't especially strong; indeed, it wasn't much stronger than saying that the choice between a dataclass and a namedtuple is a matter of taste (scissors, paper, stone; best of three).

Pondering BNFCode.parts some more, and following #97, I felt that defining the parts in two places (in BNFCode.parts and in Parts) was error-prone, irrespective of whether Parts was a dataclass or a namedtuple. Ideally, we want a solution that is less error-prone and provides us with attribute access. This led me to the solution you see here: using the dict returned by match.groupdict() to create and populate a namedtuple. (It may be possible to use this dict to create and populate a dataclass. If it is, then I'm afraid I don't know how.)

You'll notice that creating a namedtuple in this way makes it inaccessible to the tests. I think that's okay; after all, we want a solution that provides us with attribute access, not a dataclass solution or a namedtuple solution. We can simply assert against the attributes. Doing so has a slight benefit, in that it makes it clearer which part doesn't meet our expectations by providing a line number rather than just an attribute name.