### PR TITLE
Create a better repr of LabelledMatrix

### DIFF
--- a/openprescribing/data/rxdb/labelled_matrix.py
+++ b/openprescribing/data/rxdb/labelled_matrix.py
@@ -1,5 +1,6 @@
 import dataclasses
 import functools
+import reprlib
 from collections.abc import Hashable
 
 import numpy as np
@@ -52,6 +53,15 @@ class LabelledMatrix:
         new_values = np.divide(self.values, other.values, where=(other.values != 0))
         new_values[other.values == 0] = np.nan
         return self.__class__(new_values, self.row_labels, self.col_labels)
+
+    def __repr__(self):
+        args = ", ".join(f"{k}={reprlib.repr(v)}" for k, v in self.__dict__.items())
+        # The following removes most indentation added by numpy. Removing all
+        # indentation would require us to write a formatter, which seems like
+        # over-engineering. For more information, see:
+        # https://numpy.org/doc/stable/reference/generated/numpy.set_printoptions.html
+        args = " ".join(args.split())
+        return f"{self.__class__.__name__}({args})"
 
     def group_rows(self, row_label_map: tuple[tuple[Label, LabelGroup], ...]):
         """

--- a/tests/data/rxdb/test_labelled_matrix.py
+++ b/tests/data/rxdb/test_labelled_matrix.py
@@ -37,6 +37,18 @@ def test_truediv():
     )
 
 
+def test_repr():
+    matrix = LabelledMatrix(
+        np.array([range(100), range(100)]),
+        ("r1", "r2"),
+        tuple(f"c{x}" for x in range(100)),
+    )
+    assert (
+        repr(matrix)
+        == "LabelledMatrix(values=array([[ 0, ... 97, 98, 99]]), row_labels=('r1', 'r2'), col_labels=('c0', 'c1', 'c2', 'c3', 'c4', 'c5', ...))"
+    )
+
+
 def test_group_rows_by_label():
     matrix = LabelledMatrix(
         col_labels=(1, 2, 3),


### PR DESCRIPTION
Here, I've decided that "better" means "shorter" and have leaned on reprlib.repr to handle values, row_labels, and col_labels. __repr__ isn't meant to be eval-able, so I'm unconcerned if reprlib.repr truncates these properties.

Closes #64