### PR TITLE
Separate highlight from search

### DIFF
--- a/openprescribing/web/templates/bnf_codes.html
+++ b/openprescribing/web/templates/bnf_codes.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="row">
     <div class="col-lg-5">
-        <div class="card h-100">
+        <div class="card">
             <div class="card-body">
                 <h1 class="h3">Search for BNF codes</h1>
                 <form>
@@ -14,8 +14,13 @@
                     {% include "./_bnf_codes_form_controls.html" with prefix="dtr" codes=dtr_codes product_type=dtr_product_type placeholder="BNF codes for denominator, or leave blank to use list size" %}
                     <button type="submit" class="btn btn-primary">Submit</button>
           		</form>
-                <div class="mt-4 mb-3 position-relative">
-                    <label class="form-label" for="org-search">Highlight organisation (optional)</label>
+            </div>
+        </div>
+        <div class="card mt-3">
+            <div class="card-body">
+                <h2 class="h5">Highlight organisation</h2>
+                <div class="position-relative mb-2">
+                    <label class="form-label" for="org-search">Name or code of organisation to highlight</label>
                     <input
                         id="org-search"
                         type="search"

--- a/tests/functional/test_bnf_codes.py
+++ b/tests/functional/test_bnf_codes.py
@@ -30,8 +30,12 @@ def test_bnf_codes(live_server, page: Page, sample_data):
     )
 
     # Test if the org search works
-    page.get_by_role("searchbox", name="Highlight organisation (").click()
-    page.get_by_role("searchbox", name="Highlight organisation (").fill("ICB 1")
+    page.get_by_role(
+        "searchbox", name="Name or code of organisation to highlight"
+    ).click()
+    page.get_by_role(
+        "searchbox", name="Name or code of organisation to highlight"
+    ).fill("ICB 1")
     page.get_by_role("button", name="ICB 1 ICB01 - ICB").click()
 
     expect(page).to_have_url(


### PR DESCRIPTION
This separates the elements that allow a user to highlight a single organisation from the elements that allow a user to search for BNF codes. We do this because the interaction that activates the former (click an item in a list) isn't the same as the interaction that activates the latter (click a button). In other words, we're communicating to the user that these elements are not part of the same group.

Clearly, this isn't the last word in the layout of these elements. However, it's hopefully an uncontroversial step in the right direction.

<img width="3778" height="2332" alt="Screenshot showing separate highlight and search elements" src="https://github.com/user-attachments/assets/dec28126-343d-49f6-a34c-ec0a8475f5ed" />
