### PR TITLE
Move deciles chart

### DIFF
--- a/openprescribing/web/templates/bnf_codes.html
+++ b/openprescribing/web/templates/bnf_codes.html
@@ -45,6 +45,7 @@
             <div class="card-body">
                 {% if ntr_codes %}
                 <h1 class="h4">Prescribing data</h1>
+                <div id="prescribing-chart" class="py-3">Loading chart...</div>
                 <div class="row">
                     <div class="col-6">
                         <h2 class="h5">Numerator</h2>
@@ -65,7 +66,6 @@
                     </div>
                 </div>
                 {% endif %}
-                <div id="prescribing-chart" class="py-3">Loading chart...</div>
                 {% else %}
                 <div class="text-center text-muted py-5">
                     <p>Search for BNF codes to see prescribing data.</p>


### PR DESCRIPTION
As @a-d-brown pointed out today, sometimes the information about numerators and denominators can grow and grow, pushing the deciles chart down the page. As the deciles chart is more important, it should come first.

Before:

<img width="3778" height="2332" alt="Before. Screenshot of deciles chart above information about numerators and denominators" src="https://github.com/user-attachments/assets/65196df3-9746-4094-9d8e-6390a0682553" />

After:

<img width="3778" height="2332" alt="After. Screenshot of deciles chart below information about numerators and denominators" src="https://github.com/user-attachments/assets/b0309462-10f7-4e26-9e31-33c3ab283aa5" />

