### PR TITLE
Cache BNFCode.parts

### DIFF
--- a/openprescribing/data/models/bnf_codes.py
+++ b/openprescribing/data/models/bnf_codes.py
@@ -1,5 +1,6 @@
 import collections
 import re
+from functools import cached_property
 
 from django.db import models
 
@@ -21,7 +22,7 @@ class BNFCode(models.Model):
     level = models.IntegerField(choices=Level)
     name = models.TextField()
 
-    @property
+    @cached_property
     def parts(self):
         pattern = r"""
             \A


### PR DESCRIPTION
This gets called twelve times times by is_generic_equivalent_of (six times for each of the two BNFCode objects), and is_generic_equivalent_of gets called hundreds of times when building a BNF table for a chemical substance with lots presentations.

Adding this takes the time to run make_bnf_table for Methotrexate (1001030U0) from ~5s to ~0s.

The extra efficiency gained by compiling the regex in advance is minimial, and is offset by the added complexity.