### PR TITLE
BNF presentation picker 2: support including/excluding nodes in the tree

### DIFF
--- a/openprescribing/data/models/bnf_codes.py
+++ b/openprescribing/data/models/bnf_codes.py
@@ -59,3 +59,9 @@ class BNFCode(models.Model):
             and self.parts.chemical_substance == other.parts.chemical_substance
             and self.parts.strength_and_formulation == other.parts.generic_equivalent
         )
+
+    @property
+    def strength_and_formulation_code(self):
+        assert self.level == BNFCode.Level.PRESENTATION
+        assert self.is_generic()
+        return self.code[:9] + "_" + self.code[-2:]

--- a/openprescribing/web/presenters.py
+++ b/openprescribing/web/presenters.py
@@ -32,6 +32,10 @@ def make_bnf_table(products, presentations):
     There is one header per product and one row per generic presentation.  (Or, for the
     chemical substances without generic presentations, one single row.)
 
+    Each row is represented as a dictionary with the keys "code" and "cells", where the
+    code is the strength and formulation code of the generic presentation.  (Or None,
+    for the chemical substances without generic presentations.)
+
     Each cell may contain any number of presentations.
 
     Products and presentations are represented as dictionaries with the keys "code" and
@@ -42,7 +46,10 @@ def make_bnf_table(products, presentations):
     generic_equivalents = [p for p in presentations if p.is_generic()]
 
     if generic_equivalents:
-        rows = [[[] for _ in products] for _ in generic_equivalents]
+        rows = [
+            {"code": ge.strength_and_formulation_code, "cells": [[] for _ in products]}
+            for ge in generic_equivalents
+        ]
         for p in presentations:
             row_ix = get_index(
                 generic_equivalents,
@@ -52,15 +59,15 @@ def make_bnf_table(products, presentations):
                 products,
                 lambda product: product.is_ancestor_of(p),
             )
-            rows[row_ix][col_ix].append(to_dict(p))
+            rows[row_ix]["cells"][col_ix].append(to_dict(p))
     else:
-        rows = [[[] for _ in products]]
+        rows = [{"code": None, "cells": [[] for _ in products]}]
         for p in presentations:
             col_ix = get_index(
                 products,
                 lambda product: product.is_ancestor_of(p),
             )
-            rows[0][col_ix].append(to_dict(p))
+            rows[0]["cells"][col_ix].append(to_dict(p))
 
     return headers, rows
 

--- a/openprescribing/web/static/css/openprescribing.css
+++ b/openprescribing/web/static/css/openprescribing.css
@@ -56,6 +56,48 @@
   li[data-included] li[data-excluded] span:hover {
     background-color: #ffffff;
   }
+
+  /* chemical substance included directly, with some descendants excluded */
+  /* revolting vertical stripes */
+  li[data-partially-included] > span {
+    background: repeating-linear-gradient(
+      90deg,
+      var(--included-directly) 0,
+      var(--included-directly) 36px,
+      #ffffff 36px,
+      #ffffff 72px
+    );
+  }
+  li[data-partially-included] > span:hover {
+    background: repeating-linear-gradient(
+      90deg,
+      var(--included-directly-hover) 0,
+      var(--included-directly-hover) 36px,
+      #ffffff 36px,
+      #ffffff 72px
+    );
+  }
+
+  /* chemical substance included indirectly, with some descendants excluded */
+  /* more revolting vertical stripes */
+  li[data-included] li[data-partially-included] > span {
+    background: repeating-linear-gradient(
+      90deg,
+      var(--included-indirectly) 0,
+      var(--included-indirectly) 36px,
+      #ffffff 36px,
+      #ffffff 72px
+    );
+  }
+  li[data-included] li[data-partially-included] > span:hover {
+    background: repeating-linear-gradient(
+      90deg,
+      var(--included-indirectly-hover) 0,
+      var(--included-indirectly-hover) 36px,
+      #ffffff 36px,
+      #ffffff 72px
+    );
+  }
 }
 
 @scope (#bnf-table) {
@@ -70,5 +112,27 @@
   }
   li:last-child {
     border-bottom: 0;
+  }
+}
+
+@scope (#bnf-table[data-selectable]) {
+  td {
+    cursor: pointer;
+    user-select: none;
+  }
+
+  /* included, indirectly */
+  table[data-included] td {
+    background-color: var(--included-indirectly);
+  }
+
+  /* included, directly */
+  tr[data-included] td {
+    background-color: var(--included-directly);
+  }
+
+  /* excluded */
+  table[data-included] tr[data-excluded] td {
+    background-color: #ffffff;
   }
 }

--- a/openprescribing/web/templates/_bnf_table_modal.html
+++ b/openprescribing/web/templates/_bnf_table_modal.html
@@ -7,6 +7,11 @@
       </div>
       <div class="modal-body">
       </div>
+      {% if include_footer %}
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Update Query</button>
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/openprescribing/web/templates/bnf_browser_table.html
+++ b/openprescribing/web/templates/bnf_browser_table.html
@@ -6,8 +6,8 @@
             {% endfor %}
         </tr>
         {% for row in rows %}
-        <tr>
-            {% for cell in row %}
+        <tr{% if row.code %} data-code="{{ row.code }}"{% endif %}>
+            {% for cell in row.cells %}
             <td>
                 {% if cell|length > 0 %}
                 <ul>

--- a/openprescribing/web/templates/bnf_codes.html
+++ b/openprescribing/web/templates/bnf_codes.html
@@ -6,7 +6,7 @@
     <div class="col-lg-5">
         <div class="card">
             <div class="card-body">
-                <h1 class="h3">Search for BNF codes</h1>
+                <h1 class="h4">Prescribing query</h1>
                 <form>
                     <h2 class="h5">Numerator</h2>
                     {% include "./_bnf_codes_form_controls.html" with prefix="ntr" codes=ntr_codes product_type=ntr_product_type placeholder="BNF codes for numerator" %}

--- a/tests/data/models/test_bnf_codes.py
+++ b/tests/data/models/test_bnf_codes.py
@@ -53,5 +53,10 @@ def test_is_generic_equivalent_of(bnf_codes):
     )
 
 
+@pytest.mark.django_db(databases=["data"])
+def test_strength_and_formulation_code(bnf_codes):
+    assert bnf_code("1001030U0AAABAB").strength_and_formulation_code == "1001030U0_AB"
+
+
 def bnf_code(code):
     return BNFCode.objects.get(code=code)

--- a/tests/functional/test_bnf_codes.py
+++ b/tests/functional/test_bnf_codes.py
@@ -7,29 +7,34 @@ pytestmark = pytest.mark.functional
 
 @pytest.mark.django_db(databases=["data"], transaction=True)
 def test_bnf_codes(live_server, page: Page, sample_data):
-    page.goto(live_server.url)
-    expect(page).to_have_url(live_server.url + "/")
-
-    page.get_by_role(
-        "link", name="Prescribing data over time for multiple BNF Codes"
-    ).click()
-    expect(page).to_have_url(live_server.url + "/bnf_codes/")
-
-    # Wait for the JS to load, just in case
-    page.wait_for_load_state("networkidle")
-
-    numerator_codes = page.get_by_placeholder("BNF codes for numerator")
-    numerator_codes.click()
-    numerator_codes.fill("1001030U0AA\n-1001030U0AAACAC\n")
-
+    # This is a limited smoke test that checks that codes can be selected from the table
+    # (numerator) and the tree (denominator), and that on form submission we're directed
+    # to the expected URL.
+    page.goto(live_server.url + "/bnf_codes/")
+    page.get_by_role("textbox", name="BNF codes for numerator").click()
+    page.get_by_role("textbox", name="Search by name or code").click()
+    page.get_by_role("textbox", name="Search by name or code").fill("metho")
+    page.get_by_role("button", name="Search").click()
+    page.get_by_text("1001030U0 Methotrexate").click()
+    page.get_by_text("1001030U0AAACAC").click(modifiers=["ControlOrMeta"])
+    page.locator("#bnf-table-modal").get_by_role("button", name="Update Query").click()
+    page.locator("#bnf-tree-modal").get_by_role("button", name="Update Query").click()
+    page.get_by_role("textbox", name="BNF codes for denominator").click()
+    page.get_by_role("textbox", name="Search by name or code").click()
+    page.get_by_role("textbox", name="Search by name or code").fill("metho")
+    page.get_by_role("button", name="Search").click()
+    page.locator("#bnf-tree-modal").get_by_text("1001030U0 Methotrexate").click(
+        modifiers=["ControlOrMeta"]
+    )
+    page.locator("#bnf-tree-modal").get_by_role("button", name="Update Query").click()
     page.get_by_role("button", name="Submit").click()
 
     expect(page).to_have_url(
         live_server.url
-        + "/bnf_codes/?ntr_codes=1001030U0AA%0D%0A-1001030U0AAACAC%0D%0A&ntr_product_type=all&dtr_codes=&dtr_product_type=all"
+        + "/bnf_codes/?ntr_codes=1001030U0_AC&ntr_product_type=all&dtr_codes=1001030U0&dtr_product_type=all"
     )
 
-    # Test if the org search works
+    # Test org search
     page.get_by_role(
         "searchbox", name="Name or code of organisation to highlight"
     ).click()
@@ -40,5 +45,5 @@ def test_bnf_codes(live_server, page: Page, sample_data):
 
     expect(page).to_have_url(
         live_server.url
-        + "/bnf_codes/?ntr_codes=1001030U0AA%0D%0A-1001030U0AAACAC%0D%0A&ntr_product_type=all&dtr_codes=&dtr_product_type=all&org_id=ICB01"
+        + "/bnf_codes/?ntr_codes=1001030U0_AC&ntr_product_type=all&dtr_codes=1001030U0&dtr_product_type=all&org_id=ICB01"
     )

--- a/tests/web/test_presenters.py
+++ b/tests/web/test_presenters.py
@@ -89,14 +89,20 @@ def test_make_bnf_table_with_generic_products(bnf_codes):
         {"code": "1001030U0BD", "name": "Maxtrex (Rheumatism)"},
     ]
     assert rows == [
-        [
-            [{"code": "1001030U0AAABAB", "name": "Methotrexate 2.5mg tablets"}],
-            [{"code": "1001030U0BDAAAB", "name": "Maxtrex 2.5mg tablets"}],
-        ],
-        [
-            [{"code": "1001030U0AAACAC", "name": "Methotrexate 10mg tablets"}],
-            [{"code": "1001030U0BDABAC", "name": "Maxtrex 10mg tablets"}],
-        ],
+        {
+            "code": "1001030U0_AB",
+            "cells": [
+                [{"code": "1001030U0AAABAB", "name": "Methotrexate 2.5mg tablets"}],
+                [{"code": "1001030U0BDAAAB", "name": "Maxtrex 2.5mg tablets"}],
+            ],
+        },
+        {
+            "code": "1001030U0_AC",
+            "cells": [
+                [{"code": "1001030U0AAACAC", "name": "Methotrexate 10mg tablets"}],
+                [{"code": "1001030U0BDABAC", "name": "Maxtrex 10mg tablets"}],
+            ],
+        },
     ]
 
 
@@ -116,12 +122,15 @@ def test_make_bnf_table_with_no_generic_products(bnf_codes):
         {"code": "0601060D0BS", "name": "Prestige"},
     ]
     assert rows == [
-        [
-            [
-                {
-                    "code": "0601060D0BSAAA0",
-                    "name": "Prestige Smart System testing strips",
-                }
+        {
+            "code": None,
+            "cells": [
+                [
+                    {
+                        "code": "0601060D0BSAAA0",
+                        "name": "Prestige Smart System testing strips",
+                    }
+                ],
             ],
-        ],
+        }
     ]


### PR DESCRIPTION
This PR is the second step (after #126) towards supporting selection of BNF codes via a point + click interface.  It supports including/excluding nodes from the BNF browser's tree via control-clicking on nodes.