### PR TITLE
Add `out` to use of numpy.divide

### DIFF
--- a/openprescribing/data/rxdb/labelled_matrix.py
+++ b/openprescribing/data/rxdb/labelled_matrix.py
@@ -50,7 +50,9 @@ class LabelledMatrix:
         assert self.col_labels == other.col_labels
         # NumPy's default behaviour is for 0/0 to give np.nan and x/0 to give np.inf.
         # We always want np.nan, since we might be displaying the result on a chart.
-        new_values = np.divide(self.values, other.values, where=(other.values != 0))
+        new_values = np.divide(
+            self.values, other.values, where=(other.values != 0), out=None
+        )
         new_values[other.values == 0] = np.nan
         return self.__class__(new_values, self.row_labels, self.col_labels)
 


### PR DESCRIPTION
* the `out` and `where` args are both optional
* however, if `where` is provided and `out` is not provided, then any values that evaluate to False in the `where` will be uninitialized (and presumably throw a memory protection error if accessed?)
* as of numpy-1.17.0 the use of `where` without `out` will throw a warning, and our test suite is set to fail on warnings
* see https://github.com/numpy/numpy/pull/29813 and https://numpy.org/doc/stable/reference/generated/numpy.divide.html
* part of #130 