### PR TITLE
Select a parent code when ctrl-clicked, even if a child is selected

### DIFF
--- a/openprescribing/web/static/js/prescribing-query.js
+++ b/openprescribing/web/static/js/prescribing-query.js
@@ -284,7 +284,15 @@ function handleTreeCtrlClick(li) {
   } else if (ancestorIsDirectlyExcluded(query, code)) {
     // An ancestor is excluded: do nothing
   } else if (descendantIsDirectlyIncluded(query, code)) {
-    // A descendant is included: do nothing
+    // A descendant is included:
+    // * Include this one
+    // * Remove descendant inclusions
+    query.included.push(code);
+    li.setAttribute("data-included", "");
+    li.querySelectorAll("li[data-included]").forEach((n) => {
+      removeItem(query.included, n.dataset.code);
+      n.removeAttribute("data-included");
+    });
   } else if (ancestorIsDirectlyIncluded(query, code)) {
     // An ancestor is included:
     // * Exclude this one


### PR DESCRIPTION
* previous behaviour was slightly counter-intuitive
* if a tree was collapsed, the child that was blocking the selection of a parent could be hidden & difficult to find