### PR TITLE
Select with command (meta) key for macOS

### DIFF
--- a/openprescribing/web/static/js/prescribing-query.js
+++ b/openprescribing/web/static/js/prescribing-query.js
@@ -84,7 +84,7 @@ tree.addEventListener("click", (e) => {
 
   const li = e.target.closest("li");
   if (li) {
-    if (e.ctrlKey) {
+    if (e.ctrlKey || e.metaKey) {
       handleTreeCtrlClick(li);
     } else {
       handleTreeClick(li);


### PR DESCRIPTION
This allows macOS users to select using the command key. Unfortunately, the ctrl key is hard-wired to right-click at the OS-level, for reasons that go all the way back to one-button mouse days.