### PR TITLE
Select with command (meta) key for macOS

### DIFF
--- a/openprescribing/web/static/js/prescribing-query.js
+++ b/openprescribing/web/static/js/prescribing-query.js
@@ -136,7 +136,7 @@ tableModalBody.addEventListener("htmx:afterSwap", () => {
   setTableState(table);
 
   table.addEventListener("click", (e) => {
-    if (e.ctrlKey) {
+    if (e.ctrlKey || e.metaKey) {
       const td = e.target.closest("td");
       if (td) {
         handleTableCtrlClick(td);


### PR DESCRIPTION
Should have included this in 23c57e3, but missed it.