### PR TITLE
Default to showing deciles charts for ICBs not practices

### DIFF
--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -47,7 +47,7 @@ def prescribing_deciles(request):
         org_type = org.org_type
     else:
         org = None
-        org_type = Org.OrgType.PRACTICE
+        org_type = Org.OrgType.ICB
 
     org_to_practice_ids = Org.objects.filter(org_type=org_type).with_practice_ids()
 

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -9,7 +9,7 @@ def test_prescribing_deciles(client, sample_data):
     assert rsp.status_code == 200
     assert (
         next(iter(json.loads(rsp.text)["datasets"].values()))[-1]["value"]
-        == 66.41339883307133
+        == 64.15611215168303
     )
 
 
@@ -25,7 +25,7 @@ def test_prescribing_deciles_with_exclusion(client, sample_data):
     assert rsp.status_code == 200
     assert next(iter(json.loads(rsp.text)["datasets"].values()))[-1][
         "value"
-    ] == pytest.approx(60.64, 0.001)
+    ] == pytest.approx(59.07, 0.001)
 
 
 @pytest.mark.django_db(databases=["data"])


### PR DESCRIPTION
With some queries, the practice at the 90th percentile is prescribing nothing, and so the chart shows nothing interesting.  However, unless there is very little prescribing nationally, the ICB at the 90th percentile is likely to be prescribing something, and so the chart will be more interesting.

We expect to do more work on the charts soon.

Compare this (practice deciles):

<img width="773" height="673" alt="image" src="https://github.com/user-attachments/assets/b2c3d9a2-b0e3-4776-b7d4-f521a67e105b" />

With this (ICB deciles):

<img width="773" height="673" alt="image" src="https://github.com/user-attachments/assets/977b3abd-1b4a-47a2-a3bf-976429a13708" />
