### PR TITLE
Add email address for feedback

### DIFF
--- a/openprescribing/web/templates/base.html
+++ b/openprescribing/web/templates/base.html
@@ -46,6 +46,8 @@
     <div class="bg-warning-subtle text-warning-emphasis border-bottom">
       <div class="container py-2 text-center fw-medium">
         This is a beta version of a new OpenPrescribing.
+        Do you have feedback?
+        Email <a class="text-reset" href="mailto:bennett@phc.ox.ac.uk?subject=OpenPrescribing%20Beta%20Feedback">bennett@phc.ox.ac.uk</a>.
       </div>
     </div>
 


### PR DESCRIPTION
We discussed adding this during yesterday's show-and-tell. As with 834193b, we will likely iterate on the wording. For now, this will suffice. The email address is the same as that used on <https://openprescribing.net/analyse/>.

<img width="3778" height="1958" alt="Screenshot of OpenPrescribing Beta showing email address for feedback" src="https://github.com/user-attachments/assets/2c3db389-01a5-455c-a523-01fbb4e002db" />
