### PR TITLE
Allow browser to cache api responses

### DIFF
--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -1,6 +1,7 @@
 import math
 
 from django.http import JsonResponse
+from django.views.decorators.cache import cache_control
 
 from openprescribing.data import rxdb
 from openprescribing.data.models import Org
@@ -62,6 +63,7 @@ def _build_odm(request):
     return odm, org
 
 
+@cache_control(public=True, max_age=3600)
 def prescribing_all_orgs(request):
     odm, _ = _build_odm(request)
 
@@ -74,6 +76,7 @@ def prescribing_all_orgs(request):
     )
 
 
+@cache_control(public=True, max_age=3600)
 def prescribing_deciles(request):
     odm, org = _build_odm(request)
 


### PR DESCRIPTION
* these can be expensive & slow to generate/transfer!
* they should only change when new data is imported, so we could probably set a much longer max_age - but this is fine for now
* fix #170 