### PR TITLE
Remove aria attributes

### DIFF
--- a/openprescribing/web/templates/_bnf_codes_form_controls.html
+++ b/openprescribing/web/templates/_bnf_codes_form_controls.html
@@ -18,7 +18,6 @@
         class="btn btn-outline-secondary w-100 mt-2"
         data-field="{{ prefix }}"
         data-bnf-selector
-        aria-controls="{{ prefix }}-codes-list"
     >
         Select BNF codes for {% if prefix == "ntr" %}numerator{% else %}denominator{% endif %}
     </button>

--- a/openprescribing/web/templates/query.html
+++ b/openprescribing/web/templates/query.html
@@ -32,7 +32,6 @@
                         class="list-group position-absolute top-100 start-0 end-0 mt-2 shadow d-none z-3"
                         id="org-results"
                         role="listbox"
-                        aria-label="Organisation search results"
                         style="max-height: 18rem; overflow-y: auto;"
                     ></ul>
                 </div>
@@ -84,8 +83,7 @@
                                 type="button"
                                 data-bs-toggle="collapse"
                                 data-bs-target="#collapsePresentations"
-                                aria-expanded="false"
-                                aria-controls="collapsePresentations">
+                            >
                             Presentations
                             </button>
                         </p>


### PR DESCRIPTION
Some aria attributes have crept in to our templates, possibly via copying and pasting, or through accepting LLM suggestions.  We want the site to be accessible, but doing so requires a consistent approach.