### PR TITLE
Remove aria role attributes

### DIFF
--- a/openprescribing/web/templates/_bnf_table_modal.html
+++ b/openprescribing/web/templates/_bnf_table_modal.html
@@ -1,5 +1,5 @@
-<div class="modal fade" id="bnf-table-modal" tabindex="-1" role="dialog" >
-  <div class="modal-dialog modal-xl modal-dialog-scrollable" role="document">
+<div class="modal fade" id="bnf-table-modal" tabindex="-1">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title"></h5>

--- a/openprescribing/web/templates/query.html
+++ b/openprescribing/web/templates/query.html
@@ -31,7 +31,6 @@
                     <ul
                         class="list-group position-absolute top-100 start-0 end-0 mt-2 shadow d-none z-3"
                         id="org-results"
-                        role="listbox"
                         style="max-height: 18rem; overflow-y: auto;"
                     ></ul>
                 </div>
@@ -105,8 +104,8 @@
     </div>
 </div>
 
-<div class="modal" id="bnf-tree-modal" tabindex="-1" role="dialog" >
-  <div class="modal-dialog modal-xl modal-dialog-scrollable" role="document">
+<div class="modal" id="bnf-tree-modal" tabindex="-1">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="bnf-tree-modal-title"></h5>


### PR DESCRIPTION
Similar to #180. Although these don't start with the aria prefix, role attributes are part of aria. As "No ARIA is better than bad ARIA", we should remove them. For more information, see:

* https://www.w3.org/WAI/ARIA/apg/practices/read-me-first/
* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles