### PR TITLE
Add brief explanation of deciles charts

### DIFF
--- a/openprescribing/web/templates/query.html
+++ b/openprescribing/web/templates/query.html
@@ -49,7 +49,23 @@
                         <fieldset>
                             <h2 class="h5">Show prescribing</h2>
                             <input type="radio" id="decile" name="chart_type" value="decile" selected>
-                            <label for="decile">Deciles</label><br>
+                            <label for="decile">Deciles</label>
+                            <a href="#deciles-help" class="link-secondary d-inline-flex align-items-center" data-bs-toggle="modal">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    width="16"
+                                    height="16"
+                                    fill="currentColor"
+                                    class="bi bi-info-circle"
+                                    viewBox="0 0 16 16"
+                                    focusable="false"
+                                >
+                                    <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16" />
+                                    <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533z" />
+                                    <circle cx="8" cy="4.5" r="1" />
+                                </svg>
+                            </a>
+                            <br>
                             <input type="radio" id="all_orgs" name="chart_type" value="all_orgs">
                             <label for="all_orgs">All organisations</label><br>
                         </fieldset>
@@ -99,6 +115,33 @@
                     <p>Search for BNF codes to see prescribing data.</p>
                 </div>
                 {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="deciles-help" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deciles-help-title">Understanding the deciles chart</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p>
+                    The <span style="color: blue">blue</span> lines show deciles.
+                    There are nine deciles and they divide the sorted data into ten equal parts.
+                </p>
+                <p>
+                    The thickest blue line, with long dashes rather than short dashes, shows the median.
+                    Half of all organisations are above the median; half are below.
+                </p>
+                <p>
+                    The <span style="color: red">red</span> line, if present, highlights a single organisation.
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This contributes to #157. I'd like it to be reviewed and merged before completing work on the issue, to reduce the impact of merge conflicts: We're each working in this part of the template at the moment. I'd also like to talk about the explanation with a few people, and doing that with it in production is easier.

Most of the explanation comes from [the GP Activations Dashboard](https://activations.opensafely.org/icb/QWU/). The new modal is consistent with existing modals. Red and blue may change with #65.

<img width="3808" height="1966" alt="Screenshot showing brief explanation of deciles charts" src="https://github.com/user-attachments/assets/1e365994-a98f-4eab-932e-6d59b394fb83" />
