### PR TITLE
Line chart - highlight & label orgs on hover

### DIFF
--- a/openprescribing/web/static/js/prescribing-chart.js
+++ b/openprescribing/web/static/js/prescribing-chart.js
@@ -123,6 +123,14 @@ const updateDecilesChart = (
     createDecilesChart(chartContainer);
   }
 
+  const truncate_string = (str) => {
+    const maxLength = 65;
+    if (str.length > maxLength) {
+      return `${str.slice(0, maxLength)}...`;
+    }
+    return str;
+  };
+
   const all_dataset_names = ["deciles", "all_orgs_dots", "all_orgs_line"];
   chartLoading.textContent = "Loading chart...";
   fetch(prescribingDecilesUrl)
@@ -143,6 +151,15 @@ const updateDecilesChart = (
       }
       updateOrgTypeLabel(response.org_type);
       chartResult.then((result) => {
+        const orgs = JSON.parse(document.getElementById("orgs").textContent);
+
+        if (api_dataset_name === "all_orgs") {
+          for (const element of response[api_dataset_name]) {
+            element.org_name = truncate_string(
+              orgs.find((e) => e.id === element.org).name,
+            );
+          }
+        }
         result.view.insert(add_dataset_name, response[api_dataset_name]);
         if (response.org) {
           result.view.insert("org", response.org);

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -85,11 +85,11 @@ def analysis(request):
     )
     all_orgs_labels = (
         alt.Chart(alt.NamedData("all_orgs_line"))
-        .mark_text(align="center", dx=50, dy=-25, fontSize=18, fontWeight="bold")
+        .mark_text(align="left", dx=10, dy=-25, fontSize=12, fontWeight="bold")
         .encode(
             x=alt.value(50),
             y=alt.value(50),
-            text="org:O",
+            text="org_name:O",
             color=alt.value("black"),
             opacity=alt.condition(highlight, alt.value(1), alt.value(0)),
         )

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -69,11 +69,32 @@ def analysis(request):
         .mark_line(color="#3182BD")
         .encode(x=x, y=y, detail="centile:O", strokeWidth=stroke_width)
     )
+
+    highlight = alt.selection_point(on="pointerover", empty=False)
     all_orgs_line_chart = (
         alt.Chart(alt.NamedData("all_orgs_line"))
-        .mark_line(color="grey", opacity=0.2)
-        .encode(x=x, y=y, detail="org:O")
+        .mark_line(color="grey")
+        .encode(
+            x=x,
+            y=y,
+            detail="org:O",
+            color=alt.condition(highlight, alt.value("#3182BD"), alt.value("grey")),
+            opacity=alt.condition(highlight, alt.value(1), alt.value(0.2)),
+        )
+        .add_params(highlight)
     )
+    all_orgs_labels = (
+        alt.Chart(alt.NamedData("all_orgs_line"))
+        .mark_text(align="center", dx=50, dy=-25, fontSize=18, fontWeight="bold")
+        .encode(
+            x=alt.value(50),
+            y=alt.value(50),
+            text="org:O",
+            color=alt.value("black"),
+            opacity=alt.condition(highlight, alt.value(1), alt.value(0)),
+        )
+    )
+    all_orgs_line_chart += all_orgs_labels
     deciles_chart += all_orgs_line_chart
 
     all_orgs_dots_chart = (


### PR DESCRIPTION
* don't use tooltips, as they bafflingly don't display on hover of lines - only on hover of the data points (not the lines joining the datapoints)
* `pointerover` on the line does work as you'd expect though
* enriches dataset with org name just before insert into the chart 
* truncate names to fit on screen at a decent size

[Screencast from 20-03-26 16:39:27.webm](https://github.com/user-attachments/assets/70a59cc4-3989-4ddb-bd8f-f8eba077a372)
