### PR TITLE
Modify BNFQuery to allow querying by form/route

### DIFF
--- a/openprescribing/data/bnf_query.py
+++ b/openprescribing/data/bnf_query.py
@@ -6,7 +6,21 @@ from functools import reduce
 
 from django.db.models import Q
 
+from openprescribing.data import rxdb
+
 from .models import BNFCode
+
+
+def _get_bnf_codes_for_form_route_ids(form_route_ids):
+    with rxdb.get_cursor() as cursor:
+        results = cursor.execute(
+            f"""
+            SELECT bnf_code
+            FROM medications
+            WHERE list_has_any(form_route_ids, [{", ".join(form_route_ids)}])
+            """
+        )
+        return [x[0] for x in results.fetchall()]
 
 
 @dataclass(frozen=True)
@@ -15,14 +29,16 @@ class BNFQuery:
 
     terms: tuple[Term]
     product_type: ProductType
+    form_route_ids: tuple[str, ...] = ()
 
     PRODUCT_TYPE_DEFAULT = "all"
 
     @classmethod
-    def build(cls, raw_terms, product_type):
+    def build(cls, raw_terms, product_type, form_route_ids=()):
         return cls(
             tuple([Term.from_param_value(rt) for rt in raw_terms]),
             ProductType(product_type),
+            tuple(form_route_ids),
         )
 
     @classmethod
@@ -31,7 +47,17 @@ class BNFQuery:
 
         raw_terms = tuple(params[f"{field}_codes"].split(","))
         product_type = params.get(f"{field}_product_type", cls.PRODUCT_TYPE_DEFAULT)
-        return cls.build(raw_terms=raw_terms, product_type=product_type)
+
+        if ids := params.get(f"{field}_form_route_ids"):
+            form_route_ids = tuple(ids.split(","))
+        else:
+            form_route_ids = ()
+
+        return cls.build(
+            raw_terms=raw_terms,
+            product_type=product_type,
+            form_route_ids=form_route_ids,
+        )
 
     @classmethod
     def from_dict(cls, query_dict):
@@ -90,13 +116,18 @@ class BNFQuery:
         includes = [t.build_q() for t in self.terms if not t.negated]
         excludes = [t.build_q() for t in self.terms if t.negated]
 
-        codes = list(
+        codes = (
             BNFCode.objects.filter(level=BNFCode.Level.PRESENTATION)
             .filter(reduce(Q.__or__, includes, Q()))
             .exclude(reduce(Q.__or__, excludes, Q()))
-            .order_by("code")
-            .values_list("code", flat=True)
         )
+
+        if self.form_route_ids:
+            codes = codes.filter(
+                code__in=_get_bnf_codes_for_form_route_ids(self.form_route_ids)
+            )
+
+        codes = list(codes.order_by("code").values_list("code", flat=True))
 
         if self.product_type == ProductType.ALL:
             return codes
@@ -121,10 +152,14 @@ class BNFQuery:
     def to_params(self, field):
         """Serialize to URL query parameters for a field."""
 
-        return {
+        params = {
             f"{field}_codes": self.to_codes(),
             f"{field}_product_type": self.product_type.value,
         }
+        if self.form_route_ids:
+            params[f"{field}_form_route_ids"] = ",".join(self.form_route_ids)
+
+        return params
 
     def to_codes(self):
         return ",".join(t.to_param_value() for t in self.terms)

--- a/tests/data/test_bnf_query.py
+++ b/tests/data/test_bnf_query.py
@@ -1,6 +1,8 @@
 import pytest
 
 from openprescribing.data.bnf_query import BNFQuery, ProductType
+from openprescribing.data.models import BNFCode
+from tests.utils.ingest_utils import ingest_dmd_bnf_map_data, ingest_dmd_data
 
 
 @pytest.mark.django_db(databases=["data"])
@@ -69,6 +71,25 @@ def test_get_matching_presentation_codes_for_branded_with_strength_and_formulati
     ]
 
 
+@pytest.mark.django_db(databases=["data"], transaction=True)
+def test_get_matching_presentation_codes_for_form_route_ids(rxdb, settings, tmp_path):
+    rxdb.ingest([{}])
+    ingest_dmd_data(settings, tmp_path)
+    ingest_dmd_bnf_map_data(settings, tmp_path)
+    # The following appears in the dm+d -> BNF data/mapping data
+    BNFCode(code="0203020C0AAAAAA", level=BNFCode.Level.PRESENTATION).save()
+    # The following doesn't appear in the dm+d -> BNF data/mapping data
+    BNFCode(code="1001030U0BDABAC", level=BNFCode.Level.PRESENTATION).save()
+    query = BNFQuery.from_params(
+        "ntr",
+        {
+            "ntr_codes": "0203020C0AAAAAA",
+            "ntr_form_route_ids": "0024",
+        },
+    )
+    assert query.get_matching_presentation_codes() == ["0203020C0AAAAAA"]
+
+
 @pytest.mark.django_db(databases=["data"])
 def test_describe_search_for_all_product_types(bnf_codes):
     query = BNFQuery.build(["1001030U0", "-1001030U0_AB"], ProductType.ALL)
@@ -116,11 +137,32 @@ def test_from_params():
     assert query == BNFQuery.build(["01", "-0101"], ProductType.GENERIC)
 
 
+def test_from_params_with_form_route_ids_key_not_val():
+    query = BNFQuery.from_params(
+        "ntr",
+        {
+            "ntr_codes": "01",
+            "ntr_product_type": "generic",
+            "ntr_form_route_ids": "",
+        },
+    )
+    assert query.form_route_ids == ()
+
+
 def test_to_params():
     query = BNFQuery.build(["01", "-0101"], ProductType.GENERIC)
     assert query.to_params("ntr") == {
         "ntr_codes": "01,-0101",
         "ntr_product_type": "generic",
+    }
+
+
+def test_to_params_with_form_route_ids():
+    query = BNFQuery.build(["01", "-0101"], ProductType.GENERIC, ("1", "6"))
+    assert query.to_params("ntr") == {
+        "ntr_codes": "01,-0101",
+        "ntr_product_type": "generic",
+        "ntr_form_route_ids": "1,6",
     }
 
 


### PR DESCRIPTION
This allows us to get presentation codes that match one or more BNF codes and one or more form/route IDs. See #263.