### PR TITLE
Create simple view of YAML measures

### DIFF
--- a/measure_definitions/detemir.yaml
+++ b/measure_definitions/detemir.yaml
@@ -1,7 +1,7 @@
 # loosely based on insulin_detemir measure
 
 metadata:
-  title: Prescribing of Insulin detemir
+  title: Insulin detemir
 output:
     numerator: bnf_items
     denominator: list_size

--- a/openprescribing/data/measures/__init__.py
+++ b/openprescribing/data/measures/__init__.py
@@ -1,6 +1,4 @@
-from .measures import load_measure
+from .measures import all_measure_details, load_measure
 
 
-__all__ = [
-    "load_measure",
-]
+__all__ = ["load_measure", "all_measure_details"]

--- a/openprescribing/data/measures/measures.py
+++ b/openprescribing/data/measures/measures.py
@@ -3,12 +3,22 @@ from pathlib import Path
 import yaml
 
 
+MEASURE_DEFINITIONS_PATH = Path(__file__).parents[3] / "measure_definitions"
+
+
 def load_measure(measure_name):
-    with open(
-        Path(__file__).parents[3] / "measure_definitions" / f"{measure_name}.yaml"
-    ) as f:
+    with open(MEASURE_DEFINITIONS_PATH / f"{measure_name}.yaml") as f:
         measure_yaml = yaml.safe_load(f)
     return measure_yaml
+
+
+def all_measure_details():
+    measure_names = [f.stem for f in MEASURE_DEFINITIONS_PATH.iterdir()]
+    measure_details = [
+        {"name": f, "title": load_measure(f)["metadata"]["title"]}
+        for f in measure_names
+    ]
+    return measure_details
 
 
 # TODO

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -10,7 +10,9 @@
 
 <div class="d-none d-lg-block">
     <div class="row">
-        <div class="col-lg-5">
+
+        <div class="col-lg-5 {% if measure %} d-none {% endif %}">
+
             <div class="card">
                 <div class="card-body">
                     <h1 class="h4">Prescribing query</h1>

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -71,7 +71,10 @@
             <div class="card h-100">
                 <div class="card-body">
                     {% if analysis %}
-                    <h1 class="h4">Prescribing data</h1>
+                    <h1 class="h3">Prescribing data</h1>
+                    {% if measure %}
+                    <h1 class="h4">{{ measure_title }}</h1>
+                    {% endif %}
                     <div id="deciles-chart-outer" style="height: 400px;">
                         <div id="deciles-chart-loading" class="py-3 position-absolute">
                             Loading chart...

--- a/openprescribing/web/templates/measure_list.html
+++ b/openprescribing/web/templates/measure_list.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+
+<div class="row">
+    <div class="col-lg-5 {% if measure %} d-none {% endif %}">
+        <div class="card">
+            <div class="card-body">
+                <h1 class="h4">List of measures</h1>
+                <ul>
+                    {% for measure in measures  %}
+                    <li><a href="/measures/{{ measure.name }}/">{{ measure.title }}</a></li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/openprescribing/web/urls.py
+++ b/openprescribing/web/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     path("feedback/comment/", views.feedback_comment, name="feedback_comment"),
     path("bnf/", views.bnf_browser_tree),
     path("bnf/<slug:code>/", views.bnf_browser_table),
+    path("measures/<slug:measure_name>/", views.measure),
 ]

--- a/openprescribing/web/urls.py
+++ b/openprescribing/web/urls.py
@@ -19,5 +19,6 @@ urlpatterns = [
     path("feedback/comment/", views.feedback_comment, name="feedback_comment"),
     path("bnf/", views.bnf_browser_tree),
     path("bnf/<slug:code>/", views.bnf_browser_table),
+    path("measures/", views.all_measures),
     path("measures/<slug:measure_name>/", views.measure),
 ]

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -8,6 +8,7 @@ from django.views.decorators.http import require_POST
 
 from openprescribing.data.analysis import Analysis
 from openprescribing.data.bnf_query import BNFQuery
+from openprescribing.data.measures import load_measure
 from openprescribing.data.models import BNFCode, Org
 
 from .analysis_presentation import AnalysisPresentation
@@ -21,14 +22,7 @@ from .presenters import (
 )
 
 
-def analysis(request):
-    analysis_presentation = AnalysisPresentation.from_params(request.GET)
-
-    if "ntr_codes" in request.GET:
-        analysis = Analysis.from_params(request.GET)
-    else:
-        analysis = None
-
+def _build_analysis_context(analysis):
     deciles_api_url = None
     all_orgs_api_url = None
     org = None
@@ -106,7 +100,6 @@ def analysis(request):
 
     ctx = {
         "analysis": analysis,
-        "analysis_presentation": analysis_presentation,
         "code_to_name": code_to_name,
         "ntr_dtr_intersection_table": ntr_dtr_intersection_table,
         "org": org,
@@ -117,6 +110,32 @@ def analysis(request):
         "tree": tree,
         "deciles_chart": deciles_chart.to_dict(),
     }
+
+    return ctx
+
+
+def analysis(request):
+    analysis_presentation = AnalysisPresentation.from_params(request.GET)
+
+    if "ntr_codes" in request.GET:
+        analysis = Analysis.from_params(request.GET)
+    else:
+        analysis = None
+
+    ctx = _build_analysis_context(analysis)
+    ctx["measure"] = False
+    ctx["analysis_presentation"] = analysis_presentation
+
+    return render(request, "analysis.html", ctx)
+
+
+def measure(request, measure_name):
+    analysis_dict = load_measure(measure_name)
+    analysis = Analysis.from_dict(analysis_dict)
+
+    ctx = _build_analysis_context(analysis)
+    ctx["measure"] = True
+    ctx["analysis_presentation"] = None
 
     return render(request, "analysis.html", ctx)
 

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -135,6 +135,7 @@ def measure(request, measure_name):
 
     ctx = _build_analysis_context(analysis)
     ctx["measure"] = True
+    ctx["measure_title"] = analysis_dict["metadata"]["title"]
     ctx["analysis_presentation"] = None
 
     return render(request, "analysis.html", ctx)

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -8,7 +8,7 @@ from django.views.decorators.http import require_POST
 
 from openprescribing.data.analysis import Analysis
 from openprescribing.data.bnf_query import BNFQuery
-from openprescribing.data.measures import load_measure
+from openprescribing.data.measures import all_measure_details, load_measure
 from openprescribing.data.models import BNFCode, Org
 
 from .analysis_presentation import AnalysisPresentation
@@ -139,6 +139,10 @@ def measure(request, measure_name):
     ctx["analysis_presentation"] = None
 
     return render(request, "analysis.html", ctx)
+
+
+def all_measures(request):
+    return render(request, "measure_list.html", {"measures": all_measure_details()})
 
 
 def bnf_browser_tree(request):

--- a/tests/data/measures/test_measures.py
+++ b/tests/data/measures/test_measures.py
@@ -5,7 +5,7 @@ def test_load_measure():
     m = load_measure("detemir")
     assert m == {
         "metadata": {
-            "title": "Prescribing of Insulin detemir",
+            "title": "Insulin detemir",
         },
         "output": {
             "denominator": "list_size",

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -126,5 +126,8 @@ def test_feedback_comment_rejects_missing_session(client):
 
 @pytest.mark.django_db(databases=["data"])
 def test_measure(client, sample_data):
+    rsp = client.get("/measures/")
+    assert rsp.status_code == 200
+
     rsp = client.get("/measures/detemir/")
     assert rsp.status_code == 200

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -122,3 +122,9 @@ def test_feedback_comment_rejects_missing_session(client):
     assert rsp.status_code == 400
     feedback.refresh_from_db()
     assert feedback.comment == ""
+
+
+@pytest.mark.django_db(databases=["data"])
+def test_measure(client, sample_data):
+    rsp = client.get("/measures/detemir/")
+    assert rsp.status_code == 200


### PR DESCRIPTION
* use `display:none` to hide the selection UI, as the javascript errors if the UI is missing, this view might not stick around long-term, and this is easier
* urls like http://beta.openprescribing.net/measures/ and http://beta.openprescribing.net/measures/erectile-dysfunction/
* fixes #243 
<img width="1988" height="1782" alt="Screenshot from 2026-04-09 14-05-13" src="https://github.com/user-attachments/assets/2ba3d3fc-99af-46a9-a06c-0cfafee5d420" />
<img width="1206" height="958" alt="Screenshot from 2026-04-09 14-42-03" src="https://github.com/user-attachments/assets/9c943aaa-6da3-446b-aaf5-dba530914e8a" />

