### PR TITLE
Create or replace medications view

### DIFF
--- a/openprescribing/data/rxdb/create_views.sql
+++ b/openprescribing/data/rxdb/create_views.sql
@@ -3,7 +3,7 @@
 -- here. These are initialised dynamically when the RXDB connection is created so
 -- there's no need for any migrations.
 
-CREATE VIEW medications AS
+CREATE OR REPLACE VIEW medications AS
 SELECT
     id,
     bnf_code,


### PR DESCRIPTION
Previously, we just created this view; now we replace it, if it exists. We do this because under some circumstances rxdb.CONNECTION_MANAGER is reset, but the underlying connection isn't. Consequently, the first call to rxdb.get_cursor() will succeed, but subsequent calls will fail because the medications view exists.