### PR TITLE
Generate a correct SQL query if there are no matching codes

### DIFF
--- a/openprescribing/data/bnf_query.py
+++ b/openprescribing/data/bnf_query.py
@@ -75,11 +75,18 @@ class BNFQuery:
 
         codes = self.get_matching_presentation_codes()
 
-        return f"""
-        SELECT practice_id, date_id, items AS value
-        FROM prescribing
-        WHERE bnf_code IN ({", ".join(f"'{c}'" for c in codes)})
-        """
+        if codes:
+            return f"""
+            SELECT practice_id, date_id, items AS value
+            FROM prescribing
+            WHERE bnf_code IN ({", ".join(f"'{c}'" for c in codes)})
+            """
+        else:
+            return """
+            SELECT practice_id, date_id, items AS value
+            FROM prescribing
+            WHERE false
+            """
 
     def get_matching_presentation_codes(self):
         """Return list of BNF codes for presentations matching the query.

--- a/tests/data/queries/test_get_practice_date_matrix.py
+++ b/tests/data/queries/test_get_practice_date_matrix.py
@@ -99,6 +99,21 @@ def test_get_practice_date_matrix_for_bnf_query(rxdb, sample_data):
 
 
 @pytest.mark.django_db(databases=["data"])
+def test_get_practice_date_matrix_for_bnf_query_no_matching_codes(rxdb, sample_data):
+    invalid_bnf_code = "999999999"
+    query = BNFQuery.build([invalid_bnf_code], "all")
+
+    with rxdb.get_cursor() as cursor:
+        pdm = get_practice_date_matrix(cursor, query, date_count=2)
+
+    expected_pdm = get_practice_date_matrix_alternative(
+        sample_data, query, date_count=2
+    )
+
+    assert_approx_equal(pdm, expected_pdm)
+
+
+@pytest.mark.django_db(databases=["data"])
 def test_get_practice_date_matrix_for_list_sizes(rxdb, sample_data):
     query = ListSizeQuery()
 


### PR DESCRIPTION
* previously it didn't make sense to do a query with no codes
* but if you were to do something like filter codes by routes, you may have no matching presentation codes, and in that case you'd want to return valid SQL rather than barf