### PR TITLE
Fix bug with ingesting dm+d models

### DIFF
--- a/openprescribing/data/ingestors/dmd.py
+++ b/openprescribing/data/ingestors/dmd.py
@@ -24,13 +24,17 @@ def ingest(force=False):
     log.info(f"Preparing to ingest files: {latest_dir.name}")
 
     conn = duckdb.connect()
-
     with transaction.atomic(using="data"):
+        # For each model, we delete all existing instances, and (re)create new ones
+        # from the data in the parquet files.  We delete all instances first, because if
+        # we delete and create each in turn, objects that have just been created might
+        # be deleted again via cascading model deletion.
+
         for model in get_dmd_models():
-            # For each model, we delete all existing instances, and (re)create new ones
-            # from the data in the parquet files.
-            log.info(f"Ingesting {model.__name__}")
             model.objects.all().delete()
+
+        for model in get_dmd_models():
+            log.info(f"Ingesting {model.__name__}")
             table_name = model._meta.db_table
             latest_file = latest_dir / f"{table_name}.parquet"
             if not latest_file.exists():

--- a/tests/data/ingestors/test_dmd.py
+++ b/tests/data/ingestors/test_dmd.py
@@ -28,8 +28,15 @@ def test_dmd_ingest(settings, tmp_path):
     )
     assert ampp.reimbinfo.dnd.descr == "Discount not deducted - automatic"
 
-    # Attempting to re-ingest the same named file should do nothing. As a simple check for
-    # this we delete tmp_dir and re-ingest. If the code does attempt to load it then this
-    # will fail loudly.
+    # This is a regression test to ensure that we handle object deletion correctly.  We
+    # delete all objects before (re)creating new ones.  Previously we did this
+    # incorrectly, and cascading model deletion led to the deletion of objects that had
+    # only just been created.
+    dmd.ingest(force=True)
+    assert VMP.objects.filter(pk=28946311000001106).exists()
+
+    # Attempting to re-ingest the same named file without forcing should do nothing. As
+    # a simple check for this we delete tmp_dir and re-ingest. If the code does attempt
+    # to load it then this will fail loudly.
     shutil.rmtree(tmp_path / "tmp")
     dmd.ingest()


### PR DESCRIPTION
Previously, newly-created dm+d models were being deleted via cascading model deletion.  We reorder the deletion and creation operations to avoid this.