### PR TITLE
Add metadata API endpoints for dm+d query builder

### DIFF
--- a/openprescribing/data/ingestors/dmd.py
+++ b/openprescribing/data/ingestors/dmd.py
@@ -55,7 +55,9 @@ def get_dmd_models():
     return [
         model
         for model in vars(dmd_models_module).values()
-        if isinstance(model, type) and issubclass(model, models.Model)
+        if isinstance(model, type)
+        and issubclass(model, models.Model)
+        and not model._meta.abstract
     ]
 
 

--- a/openprescribing/data/models/bnf_codes.py
+++ b/openprescribing/data/models/bnf_codes.py
@@ -70,4 +70,13 @@ class BNFCode(models.Model):
     def strength_and_formulation_name(self):
         assert self.level == BNFCode.Level.PRESENTATION
         assert self.is_generic()
-        return f"{self.name} (branded and generic)"
+        if self.name.startswith("Generic "):
+            # We show this name when a user has selected all presentations -- generic
+            # and branded -- with equivalent strength and formulation.  Some generic
+            # presentations are called "Generic X", eg "Generic Gaviscon 500mg chewable
+            # tablets".  It would be misleading to show the "Generic", given that this
+            # represents all presentations with equivalent strength and formulation, so
+            # we remove it
+            return self.name.removeprefix("Generic ")
+        else:
+            return self.name

--- a/openprescribing/data/models/dmd.py
+++ b/openprescribing/data/models/dmd.py
@@ -21,9 +21,37 @@
 from django.db import models
 
 
-class VTM(models.Model):
+class DmdManager(models.Manager):
+    """Manager for dm+d models."""
+
+    def api_values(self):
+        """Return records shaped for the API."""
+
+        assert hasattr(self.model, "api_attr_mapping"), (
+            f"Cannot serialize {self.model} without an api_attr_mapping class attribute"
+        )
+        mapping = self.model.api_attr_mapping
+        records = self.values(*mapping.keys())
+        return [
+            {api_name: record[attr_name] for attr_name, api_name in mapping.items()}
+            for record in records
+        ]
+
+
+class DmdModel(models.Model):
+    """Abstract base class for dm+d models."""
+
+    objects = DmdManager()
+
+    class Meta:
+        abstract = True
+
+
+class VTM(DmdModel):
     class Meta:
         db_table = "vtm"
+
+    api_attr_mapping = {"vtmid": "id", "nm": "name"}
 
     vtmid = models.BigIntegerField(primary_key=True)
     invalid = models.BooleanField()
@@ -33,9 +61,11 @@ class VTM(models.Model):
     vtmiddt = models.DateField(null=True)
 
 
-class VMP(models.Model):
+class VMP(DmdModel):
     class Meta:
         db_table = "vmp"
+
+    api_attr_mapping = {"vpid": "id", "vtm_id": "vtm_id", "nm": "name"}
 
     vpid = models.BigIntegerField(primary_key=True)
     vpiddt = models.DateField(null=True)
@@ -114,7 +144,7 @@ class VMP(models.Model):
     )
 
 
-class VPI(models.Model):
+class VPI(DmdModel):
     class Meta:
         db_table = "vpi"
 
@@ -149,7 +179,7 @@ class VPI(models.Model):
     )
 
 
-class Ont(models.Model):
+class Ont(DmdModel):
     class Meta:
         db_table = "ont"
 
@@ -161,7 +191,7 @@ class Ont(models.Model):
     )
 
 
-class Dform(models.Model):
+class Dform(DmdModel):
     class Meta:
         db_table = "dform"
 
@@ -169,7 +199,7 @@ class Dform(models.Model):
     form = models.ForeignKey(db_column="formcd", to="Form", on_delete=models.CASCADE)
 
 
-class Droute(models.Model):
+class Droute(DmdModel):
     class Meta:
         db_table = "droute"
 
@@ -177,7 +207,7 @@ class Droute(models.Model):
     route = models.ForeignKey(db_column="routecd", to="Route", on_delete=models.CASCADE)
 
 
-class ControlInfo(models.Model):
+class ControlInfo(DmdModel):
     class Meta:
         db_table = "control_info"
 
@@ -197,9 +227,11 @@ class ControlInfo(models.Model):
     )
 
 
-class AMP(models.Model):
+class AMP(DmdModel):
     class Meta:
         db_table = "amp"
+
+    api_attr_mapping = {"apid": "id", "vmp_id": "vmp_id", "descr": "name"}
 
     apid = models.BigIntegerField(primary_key=True)
     invalid = models.BooleanField()
@@ -254,7 +286,7 @@ class AMP(models.Model):
     )
 
 
-class LicRoute(models.Model):
+class LicRoute(DmdModel):
     class Meta:
         db_table = "lic_route"
 
@@ -266,7 +298,7 @@ class LicRoute(models.Model):
     )
 
 
-class ApInfo(models.Model):
+class ApInfo(DmdModel):
     class Meta:
         db_table = "ap_info"
 
@@ -281,7 +313,7 @@ class ApInfo(models.Model):
     prod_order_no = models.CharField(max_length=20, null=True)
 
 
-class VMPP(models.Model):
+class VMPP(DmdModel):
     class Meta:
         db_table = "vmpp"
 
@@ -306,7 +338,7 @@ class VMPP(models.Model):
     )
 
 
-class Dtinfo(models.Model):
+class Dtinfo(DmdModel):
     class Meta:
         db_table = "dtinfo"
 
@@ -321,7 +353,7 @@ class Dtinfo(models.Model):
     prevprice = models.IntegerField(null=True)
 
 
-class AMPP(models.Model):
+class AMPP(DmdModel):
     class Meta:
         db_table = "ampp"
 
@@ -352,7 +384,7 @@ class AMPP(models.Model):
     discdt = models.DateField(null=True)
 
 
-class PackInfo(models.Model):
+class PackInfo(DmdModel):
     class Meta:
         db_table = "pack_info"
 
@@ -373,7 +405,7 @@ class PackInfo(models.Model):
     pack_order_no = models.CharField(max_length=20, null=True)
 
 
-class PrescribInfo(models.Model):
+class PrescribInfo(DmdModel):
     class Meta:
         db_table = "prescrib_info"
 
@@ -389,7 +421,7 @@ class PrescribInfo(models.Model):
     dent_f = models.BooleanField()
 
 
-class PriceInfo(models.Model):
+class PriceInfo(DmdModel):
     class Meta:
         db_table = "price_info"
 
@@ -404,7 +436,7 @@ class PriceInfo(models.Model):
     )
 
 
-class ReimbInfo(models.Model):
+class ReimbInfo(DmdModel):
     class Meta:
         db_table = "reimb_info"
 
@@ -430,9 +462,11 @@ class ReimbInfo(models.Model):
     fp34d = models.BooleanField()
 
 
-class Ing(models.Model):
+class Ing(DmdModel):
     class Meta:
         db_table = "ing"
+
+    api_attr_mapping = {"isid": "id", "nm": "name"}
 
     isid = models.BigIntegerField(primary_key=True)
     isiddt = models.DateField(null=True)
@@ -441,7 +475,7 @@ class Ing(models.Model):
     nm = models.CharField(max_length=255)
 
 
-class CombinationPackInd(models.Model):
+class CombinationPackInd(DmdModel):
     class Meta:
         db_table = "combination_pack_ind"
 
@@ -449,7 +483,7 @@ class CombinationPackInd(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class CombinationProdInd(models.Model):
+class CombinationProdInd(DmdModel):
     class Meta:
         db_table = "combination_prod_ind"
 
@@ -457,7 +491,7 @@ class CombinationProdInd(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class BasisOfName(models.Model):
+class BasisOfName(DmdModel):
     class Meta:
         db_table = "basis_of_name"
 
@@ -465,7 +499,7 @@ class BasisOfName(models.Model):
     descr = models.CharField(max_length=150)
 
 
-class NamechangeReason(models.Model):
+class NamechangeReason(DmdModel):
     class Meta:
         db_table = "namechange_reason"
 
@@ -474,7 +508,7 @@ class NamechangeReason(models.Model):
     descr = models.CharField(max_length=150, null=True)
 
 
-class VirtualProductPresStatus(models.Model):
+class VirtualProductPresStatus(DmdModel):
     class Meta:
         db_table = "virtual_product_pres_status"
 
@@ -482,7 +516,7 @@ class VirtualProductPresStatus(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class ControlDrugCategory(models.Model):
+class ControlDrugCategory(DmdModel):
     class Meta:
         db_table = "control_drug_category"
 
@@ -490,7 +524,7 @@ class ControlDrugCategory(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class LicensingAuthority(models.Model):
+class LicensingAuthority(DmdModel):
     class Meta:
         db_table = "licensing_authority"
 
@@ -498,7 +532,7 @@ class LicensingAuthority(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class UnitOfMeasure(models.Model):
+class UnitOfMeasure(DmdModel):
     class Meta:
         db_table = "unit_of_measure"
 
@@ -508,7 +542,7 @@ class UnitOfMeasure(models.Model):
     descr = models.CharField(max_length=150)
 
 
-class Form(models.Model):
+class Form(DmdModel):
     class Meta:
         db_table = "form"
 
@@ -518,15 +552,17 @@ class Form(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class OntFormRoute(models.Model):
+class OntFormRoute(DmdModel):
     class Meta:
         db_table = "ont_form_route"
+
+    api_attr_mapping = {"cd": "id", "descr": "descr"}
 
     cd = models.IntegerField(primary_key=True)
     descr = models.CharField(max_length=60)
 
 
-class Route(models.Model):
+class Route(DmdModel):
     class Meta:
         db_table = "route"
 
@@ -536,7 +572,7 @@ class Route(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class DtPaymentCategory(models.Model):
+class DtPaymentCategory(DmdModel):
     class Meta:
         db_table = "dt_payment_category"
 
@@ -544,7 +580,7 @@ class DtPaymentCategory(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class Supplier(models.Model):
+class Supplier(DmdModel):
     class Meta:
         db_table = "supplier"
 
@@ -555,7 +591,7 @@ class Supplier(models.Model):
     descr = models.CharField(max_length=80)
 
 
-class Flavour(models.Model):
+class Flavour(DmdModel):
     class Meta:
         db_table = "flavour"
 
@@ -563,7 +599,7 @@ class Flavour(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class Colour(models.Model):
+class Colour(DmdModel):
     class Meta:
         db_table = "colour"
 
@@ -571,7 +607,7 @@ class Colour(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class BasisOfStrnth(models.Model):
+class BasisOfStrnth(DmdModel):
     class Meta:
         db_table = "basis_of_strnth"
 
@@ -579,7 +615,7 @@ class BasisOfStrnth(models.Model):
     descr = models.CharField(max_length=150)
 
 
-class ReimbursementStatus(models.Model):
+class ReimbursementStatus(DmdModel):
     class Meta:
         db_table = "reimbursement_status"
 
@@ -587,7 +623,7 @@ class ReimbursementStatus(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class SpecCont(models.Model):
+class SpecCont(DmdModel):
     class Meta:
         db_table = "spec_cont"
 
@@ -595,7 +631,7 @@ class SpecCont(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class Dnd(models.Model):
+class Dnd(DmdModel):
     class Meta:
         db_table = "dnd"
 
@@ -603,7 +639,7 @@ class Dnd(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class VirtualProductNonAvail(models.Model):
+class VirtualProductNonAvail(DmdModel):
     class Meta:
         db_table = "virtual_product_non_avail"
 
@@ -611,7 +647,7 @@ class VirtualProductNonAvail(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class DiscontinuedInd(models.Model):
+class DiscontinuedInd(DmdModel):
     class Meta:
         db_table = "discontinued_ind"
 
@@ -619,7 +655,7 @@ class DiscontinuedInd(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class DfIndicator(models.Model):
+class DfIndicator(DmdModel):
     class Meta:
         db_table = "df_indicator"
 
@@ -627,7 +663,7 @@ class DfIndicator(models.Model):
     descr = models.CharField(max_length=20)
 
 
-class PriceBasis(models.Model):
+class PriceBasis(DmdModel):
     class Meta:
         db_table = "price_basis"
 
@@ -635,7 +671,7 @@ class PriceBasis(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class LegalCategory(models.Model):
+class LegalCategory(DmdModel):
     class Meta:
         db_table = "legal_category"
 
@@ -643,7 +679,7 @@ class LegalCategory(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class AvailabilityRestriction(models.Model):
+class AvailabilityRestriction(DmdModel):
     class Meta:
         db_table = "availability_restriction"
 
@@ -651,7 +687,7 @@ class AvailabilityRestriction(models.Model):
     descr = models.CharField(max_length=60)
 
 
-class LicensingAuthorityChangeReason(models.Model):
+class LicensingAuthorityChangeReason(DmdModel):
     class Meta:
         db_table = "licensing_authority_change_reason"
 

--- a/openprescribing/data/rxdb/create_views.sql
+++ b/openprescribing/data/rxdb/create_views.sql
@@ -11,7 +11,7 @@ SELECT
     is_amp,
     vmp_id,
     vtm_id,
-    cast(invalid AS boolean),
+    cast(invalid AS boolean) AS invalid,
     array(
         SELECT ont.formcd
         FROM ont

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -80,6 +80,39 @@ def prescribing_deciles(request):
     )
 
 
+def metadata_medications(request):
+    """Return details of all medications that have been prescribed.
+
+    Include VMPs for any prescribed AMPs, even if the VMP itself has not been
+    prescribed.
+    """
+    with rxdb.get_cursor() as cursor:
+        medications = (
+            cursor.sql(
+                """
+                SELECT * FROM medications
+                WHERE bnf_code IN (
+                    SELECT bnf_code FROM presentation
+                )
+                OR (
+                    NOT is_amp
+                    AND id IN (
+                        SELECT DISTINCT vmp_id
+                        FROM medications
+                        WHERE is_amp
+                        AND bnf_code IN (
+                            SELECT bnf_code FROM presentation
+                        )
+                    )
+                )
+                """
+            )
+            .to_arrow_table()
+            .to_pylist()
+        )
+    return JsonResponse({"medications": medications})
+
+
 class JsonResponse(DjangoJsonResponse):
     def __init__(self, *args, **kwargs):
         kwargs["json_dumps_params"] = {"allow_nan": False}

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -4,7 +4,7 @@ from django.http import JsonResponse as DjangoJsonResponse
 
 from openprescribing.data import rxdb
 from openprescribing.data.analysis import Analysis
-from openprescribing.data.models import Org
+from openprescribing.data.models import AMP, VMP, VTM, Ing, OntFormRoute, Org
 from openprescribing.data.queries import get_org_date_ratio_matrix
 
 
@@ -111,6 +111,20 @@ def metadata_medications(request):
             .to_pylist()
         )
     return JsonResponse({"medications": medications})
+
+
+def metadata_dmd(request):
+    """Return details of dm+d objects that will be used to query and display
+    medications."""
+
+    payload = {
+        "vtm": list(VTM.objects.values("vtmid", "nm")),
+        "vmp": list(VMP.objects.values("vpid", "nm")),
+        "amp": list(AMP.objects.values("apid", "descr")),
+        "ingredient": list(Ing.objects.values("isid", "nm")),
+        "ont_form_route": list(OntFormRoute.objects.values("cd", "descr")),
+    }
+    return JsonResponse(payload)
 
 
 class JsonResponse(DjangoJsonResponse):

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -118,11 +118,11 @@ def metadata_dmd(request):
     medications."""
 
     payload = {
-        "vtm": list(VTM.objects.values("vtmid", "nm")),
-        "vmp": list(VMP.objects.values("vpid", "nm")),
-        "amp": list(AMP.objects.values("apid", "descr")),
-        "ingredient": list(Ing.objects.values("isid", "nm")),
-        "ont_form_route": list(OntFormRoute.objects.values("cd", "descr")),
+        "vtm": VTM.objects.api_values(),
+        "vmp": VMP.objects.api_values(),
+        "amp": AMP.objects.api_values(),
+        "ingredient": Ing.objects.api_values(),
+        "ont_form_route": OntFormRoute.objects.api_values(),
     }
     return JsonResponse(payload)
 

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -4,7 +4,7 @@ from django.http import JsonResponse as DjangoJsonResponse
 
 from openprescribing.data import rxdb
 from openprescribing.data.analysis import Analysis
-from openprescribing.data.models import AMP, VMP, VTM, Ing, OntFormRoute, Org
+from openprescribing.data.models import AMP, VMP, VTM, BNFCode, Ing, OntFormRoute, Org
 from openprescribing.data.queries import get_org_date_ratio_matrix
 
 
@@ -125,6 +125,38 @@ def metadata_dmd(request):
         "ont_form_route": OntFormRoute.objects.api_values(),
     }
     return JsonResponse(payload)
+
+
+def metadata_bnf(request):
+    """Return details of BNF objects that will be used to query and display
+    medications.
+
+    In order to handle strength and formulation equivalents, we replace the records for
+    level 6 objects (ie BNF products) with records for strength and formulation
+    equivalents.
+
+    Chapters 20 to 23 (devices rather than medicines) have a slightly different code
+    structure, and so will need to be handled slightly differently. k
+    """
+
+    base_queryset = BNFCode.objects.exclude(code__startswith="2").order_by(
+        "level", "code"
+    )
+    strength_and_formulation_records = [
+        {
+            "code": code.strength_and_formulation_code,
+            "level": 6,
+            "name": code.strength_and_formulation_name,
+        }
+        for code in base_queryset.filter(level=BNFCode.Level.PRESENTATION)
+        if code.is_generic()
+    ]
+    records = (
+        list(base_queryset.filter(level__lte=BNFCode.Level.CHEMICAL_SUBSTANCE).values())
+        + strength_and_formulation_records
+        + list(base_queryset.filter(level=BNFCode.Level.PRESENTATION).values())
+    )
+    return JsonResponse({"bnf": records})
 
 
 class JsonResponse(DjangoJsonResponse):

--- a/openprescribing/web/static/js/build-analysis.js
+++ b/openprescribing/web/static/js/build-analysis.js
@@ -1,0 +1,66 @@
+const containerEl = document.querySelector("[data-container]");
+const loadingEl = containerEl.querySelector("[data-loading]");
+const errorEl = containerEl.querySelector("[data-error]");
+const appEl = containerEl.querySelector("[data-app]");
+const summaryEl = containerEl.querySelector("[data-summary]");
+
+const metadataUrls = {
+  medications: containerEl.dataset.medicationsUrl,
+  dmd: containerEl.dataset.dmdUrl,
+  bnf: containerEl.dataset.bnfUrl,
+};
+
+const metadata = {};
+
+const loadMetadata = async () => {
+  try {
+    const [medications, dmd, bnf] = await Promise.all(
+      Object.values(metadataUrls).map(async (url) => {
+        const response = await fetch(url);
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        return response.json();
+      }),
+    );
+
+    metadata.medications = medications;
+    metadata.dmd = dmd;
+    metadata.bnf = bnf;
+
+    renderSummary(metadata);
+    loadingEl.hidden = true;
+    appEl.hidden = false;
+  } catch (error) {
+    loadingEl.hidden = true;
+    errorEl.textContent = `Unable to load metadata: ${error.message}`;
+    errorEl.hidden = false;
+  }
+};
+
+const renderSummary = (metadata) => {
+  const fragment = document.createDocumentFragment();
+
+  Object.entries(metadata).forEach(([endpoint, type]) => {
+    const sectionEl = document.createElement("section");
+    const headingEl = document.createElement("h2");
+    const listEl = document.createElement("ul");
+
+    headingEl.textContent = endpoint;
+
+    Object.entries(type).forEach(([key, value]) => {
+      const itemEl = document.createElement("li");
+      itemEl.textContent = `${key}: ${value.length}`;
+      listEl.appendChild(itemEl);
+    });
+
+    sectionEl.append(headingEl, listEl);
+    fragment.appendChild(sectionEl);
+  });
+
+  summaryEl.replaceChildren(fragment);
+};
+
+loadMetadata();

--- a/openprescribing/web/templates/build_analysis_2.html
+++ b/openprescribing/web/templates/build_analysis_2.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+<section
+  data-container
+  data-medications-url="{% url 'api_metadata_medications' %}"
+  data-dmd-url="{% url 'api_metadata_dmd' %}"
+  data-bnf-url="{% url 'api_metadata_bnf' %}"
+>
+  <p data-loading>Loading metadata...</p>
+  <p data-error hidden role="alert"></p>
+  <div data-app hidden>
+    <h1>Metadata record counts</h1>
+    <div data-summary></div>
+  </div>
+</section>
+
+{% block extra_js %}
+<script type="module" src="{% static 'js/build-analysis.js' %}"></script>
+{% endblock %}
+{% endblock %}

--- a/openprescribing/web/urls.py
+++ b/openprescribing/web/urls.py
@@ -6,6 +6,7 @@ from . import api, views
 urlpatterns = [
     path("", views.analysis, name="analysis"),
     path("analysis/build/", views.build_analysis, name="build-analysis"),
+    path("analysis/build2/", views.build_analysis_2, name="build-analysis-2"),
     path(
         "api/prescribing-deciles/",
         api.prescribing_deciles,

--- a/openprescribing/web/urls.py
+++ b/openprescribing/web/urls.py
@@ -26,6 +26,11 @@ urlpatterns = [
         api.metadata_dmd,
         name="api_metadata_dmd",
     ),
+    path(
+        "api/metadata/bnf/",
+        api.metadata_bnf,
+        name="api_metadata_bnf",
+    ),
     path("feedback/vote/", views.feedback_vote, name="feedback_vote"),
     path("feedback/comment/", views.feedback_comment, name="feedback_comment"),
     path("bnf/", views.bnf_browser_tree),

--- a/openprescribing/web/urls.py
+++ b/openprescribing/web/urls.py
@@ -21,6 +21,11 @@ urlpatterns = [
         api.metadata_medications,
         name="api_metadata_medications",
     ),
+    path(
+        "api/metadata/dmd/",
+        api.metadata_dmd,
+        name="api_metadata_dmd",
+    ),
     path("feedback/vote/", views.feedback_vote, name="feedback_vote"),
     path("feedback/comment/", views.feedback_comment, name="feedback_comment"),
     path("bnf/", views.bnf_browser_tree),

--- a/openprescribing/web/urls.py
+++ b/openprescribing/web/urls.py
@@ -16,6 +16,11 @@ urlpatterns = [
         api.prescribing_all_orgs,
         name="api_prescribing_all_orgs",
     ),
+    path(
+        "api/metadata/medications/",
+        api.metadata_medications,
+        name="api_metadata_medications",
+    ),
     path("feedback/vote/", views.feedback_vote, name="feedback_vote"),
     path("feedback/comment/", views.feedback_comment, name="feedback_comment"),
     path("bnf/", views.bnf_browser_tree),

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -145,6 +145,11 @@ def build_analysis(request):
     return render(request, "build_analysis.html", ctx)
 
 
+def build_analysis_2(request):  # pragma: no cover
+    # This will replace build_analysis when it is finished
+    return render(request, "build_analysis_2.html")
+
+
 def measure(request, measure_name):
     analysis_dict = load_measure(measure_name)
     analysis_dict["org_id"] = request.GET.get("org_id")

--- a/tests/data/models/test_bnf_codes.py
+++ b/tests/data/models/test_bnf_codes.py
@@ -1,10 +1,7 @@
-import pytest
-
 from openprescribing.data.models import BNFCode
 
 
-@pytest.mark.django_db(databases=["data"])
-def test_parts(bnf_codes):
+def test_parts():
     parts_of_chapter = bnf_code("10").parts
     assert parts_of_chapter.chapter == "10"
     assert parts_of_chapter.section is None
@@ -26,16 +23,14 @@ def test_parts(bnf_codes):
     assert parts_of_presentation.generic_equivalent == "AC"
 
 
-@pytest.mark.django_db(databases=["data"])
-def test_is_generic(bnf_codes):
+def test_is_generic():
     assert bnf_code("1001030U0AA").is_generic()
     assert not bnf_code("1001030U0BD").is_generic()
     assert bnf_code("1001030U0AAABAB").is_generic()
     assert not bnf_code("1001030U0BDAAAB").is_generic()
 
 
-@pytest.mark.django_db(databases=["data"])
-def test_is_ancestor_of(bnf_codes):
+def test_is_ancestor_of():
     assert bnf_code("1001").is_ancestor_of(bnf_code("100103"))
     assert bnf_code("1001030U0").is_ancestor_of(bnf_code("1001030U0AA"))
     assert bnf_code("1001030U0AA").is_ancestor_of(bnf_code("1001030U0AAABAB"))
@@ -43,8 +38,7 @@ def test_is_ancestor_of(bnf_codes):
     assert not bnf_code("1001030U0AA").is_ancestor_of(bnf_code("1001030U0AA"))
 
 
-@pytest.mark.django_db(databases=["data"])
-def test_is_generic_equivalent_of(bnf_codes):
+def test_is_generic_equivalent_of():
     assert bnf_code("1001030U0AAABAB").is_generic_equivalent_of(
         bnf_code("1001030U0BDAAAB")
     )
@@ -53,18 +47,28 @@ def test_is_generic_equivalent_of(bnf_codes):
     )
 
 
-@pytest.mark.django_db(databases=["data"])
-def test_strength_and_formulation_code(bnf_codes):
+def test_strength_and_formulation_code():
     assert bnf_code("1001030U0AAABAB").strength_and_formulation_code == "1001030U0_AB"
 
 
-@pytest.mark.django_db(databases=["data"])
-def test_strength_and_formulation_name(bnf_codes):
+def test_strength_and_formulation_name():
     assert (
-        bnf_code("1001030U0AAABAB").strength_and_formulation_name
+        bnf_code(
+            "1001030U0AAABAB",
+            name="Methotrexate 2.5mg tablets",
+        ).strength_and_formulation_name
         == "Methotrexate 2.5mg tablets (branded and generic)"
     )
 
 
-def bnf_code(code):
-    return BNFCode.objects.get(code=code)
+def bnf_code(code, name=""):
+    level = {
+        2: BNFCode.Level.CHAPTER,
+        4: BNFCode.Level.SECTION,
+        6: BNFCode.Level.PARAGRAPH,
+        8: BNFCode.Level.SUBPARAGRAPH,
+        9: BNFCode.Level.CHEMICAL_SUBSTANCE,
+        11: BNFCode.Level.PRODUCT,
+        15: BNFCode.Level.PRESENTATION,
+    }[len(code)]
+    return BNFCode(code=code, level=level, name=name)

--- a/tests/data/models/test_bnf_codes.py
+++ b/tests/data/models/test_bnf_codes.py
@@ -57,7 +57,17 @@ def test_strength_and_formulation_name():
             "1001030U0AAABAB",
             name="Methotrexate 2.5mg tablets",
         ).strength_and_formulation_name
-        == "Methotrexate 2.5mg tablets (branded and generic)"
+        == "Methotrexate 2.5mg tablets"
+    )
+
+
+def test_strength_and_formulation_name_generic():
+    assert (
+        bnf_code(
+            "0101021B0AAAGAG",
+            name="Generic Gaviscon 500mg chewable tablets sugar free",
+        ).strength_and_formulation_name
+        == "Gaviscon 500mg chewable tablets sugar free"
     )
 
 

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -136,7 +136,7 @@ def test_metadata_bnf(client, bnf_codes):
     assert {
         "code": "1001030U0_AB",
         "level": 6,
-        "name": "Methotrexate 2.5mg tablets (branded and generic)",
+        "name": "Methotrexate 2.5mg tablets",
     } in payload["bnf"]
     assert {
         "code": "1001030U0BDAAAB",

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -91,6 +91,32 @@ def test_metadata_medications(client, rxdb, settings, tmp_path):
     } in payload["medications"]
 
 
+@pytest.mark.django_db(databases=["data"])
+def test_metadata_dmd(client, settings, tmp_path):
+    ingest_dmd_data(settings, tmp_path)
+    rsp = client.get("/api/metadata/dmd/")
+    payload = rsp.json()
+    assert {
+        "vtmid": 108502004,
+        "nm": "Adenosine",
+    } in payload["vtm"]
+    assert {
+        "vpid": 35894711000001106,
+        "nm": "Adenosine 6mg/2ml solution for injection vials",
+    } in payload["vmp"]
+    assert {
+        "apid": 4744411000001104,
+        "descr": "Adenocor 6mg/2ml solution for injection vials (Sanofi)",
+    } in payload["amp"]
+    assert {
+        "isid": 35431001,
+        "nm": "Adenosine",
+    } in payload["ingredient"]
+    assert {"cd": 24, "descr": "solutioninjection.intravenous"} in payload[
+        "ont_form_route"
+    ]
+
+
 def test_nans_to_nones():
     records = [{"k1": 1.0, "k2": "aaa"}, {"k1": float("NaN"), "k2": "bbb"}]
     api.nans_to_nones(records)

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -119,6 +119,32 @@ def test_metadata_dmd(client, settings, tmp_path):
     ]
 
 
+@pytest.mark.django_db(databases=["data"])
+def test_metadata_bnf(client, bnf_codes):
+    rsp = client.get("/api/metadata/bnf/")
+    payload = rsp.json()
+    assert {
+        "code": "10",
+        "level": 1,
+        "name": "Musculoskeletal and Joint Diseases",
+    } in payload["bnf"]
+    assert {
+        "code": "1001030U0",
+        "level": 5,
+        "name": "Methotrexate",
+    } in payload["bnf"]
+    assert {
+        "code": "1001030U0_AB",
+        "level": 6,
+        "name": "Methotrexate 2.5mg tablets (branded and generic)",
+    } in payload["bnf"]
+    assert {
+        "code": "1001030U0BDAAAB",
+        "level": 7,
+        "name": "Maxtrex 2.5mg tablets",
+    } in payload["bnf"]
+
+
 def test_nans_to_nones():
     records = [{"k1": 1.0, "k2": "aaa"}, {"k1": float("NaN"), "k2": "bbb"}]
     api.nans_to_nones(records)

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -97,22 +97,24 @@ def test_metadata_dmd(client, settings, tmp_path):
     rsp = client.get("/api/metadata/dmd/")
     payload = rsp.json()
     assert {
-        "vtmid": 108502004,
-        "nm": "Adenosine",
+        "id": 108502004,
+        "name": "Adenosine",
     } in payload["vtm"]
     assert {
-        "vpid": 35894711000001106,
-        "nm": "Adenosine 6mg/2ml solution for injection vials",
+        "id": 35894711000001106,
+        "vtm_id": 108502004,
+        "name": "Adenosine 6mg/2ml solution for injection vials",
     } in payload["vmp"]
     assert {
-        "apid": 4744411000001104,
-        "descr": "Adenocor 6mg/2ml solution for injection vials (Sanofi)",
+        "id": 4744411000001104,
+        "vmp_id": 35894711000001106,
+        "name": "Adenocor 6mg/2ml solution for injection vials (Sanofi)",
     } in payload["amp"]
     assert {
-        "isid": 35431001,
-        "nm": "Adenosine",
+        "id": 35431001,
+        "name": "Adenosine",
     } in payload["ingredient"]
-    assert {"cd": 24, "descr": "solutioninjection.intravenous"} in payload[
+    assert {"id": 24, "descr": "solutioninjection.intravenous"} in payload[
         "ont_form_route"
     ]
 

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 
 from openprescribing.web import api
+from tests.utils.ingest_utils import ingest_dmd_bnf_map_data, ingest_dmd_data
 
 
 @pytest.mark.django_db(databases=["data"])
@@ -56,6 +57,38 @@ def test_prescribing_deciles_with_denominator(client, sample_data):
     assert rsp.status_code == 200
     assert payload["deciles"][-1]["value"] == pytest.approx(27.14, 0.001)
     assert payload["org"] == []
+
+
+@pytest.mark.django_db(databases=["data"], transaction=True)
+def test_metadata_medications(client, rxdb, settings, tmp_path):
+    rxdb.ingest([{"bnf_code": "1106000X0AAA4A4"}])
+    ingest_dmd_data(settings, tmp_path)
+    ingest_dmd_bnf_map_data(settings, tmp_path)
+    rsp = client.get("/api/metadata/medications/")
+    payload = rsp.json()
+
+    assert {
+        "id": 9393711000001102,
+        "bnf_code": "1106000X0AAA4A4",
+        "name": "Pilocarpine hydrochloride 6% eye drops preservative free (Special Order)",
+        "is_amp": True,
+        "vmp_id": 36016311000001102,
+        "vtm_id": 90356005,
+        "invalid": False,
+        "form_route_ids": [173],
+        "ingredient_ids": [387035001],
+    } in payload["medications"]
+    assert {
+        "id": 36016311000001102,
+        "bnf_code": "1106000X0AAA4A4",
+        "name": "Pilocarpine hydrochloride 6% eye drops preservative free",
+        "is_amp": False,
+        "vmp_id": 36016311000001102,
+        "vtm_id": 90356005,
+        "invalid": False,
+        "form_route_ids": [173],
+        "ingredient_ids": [387035001],
+    } in payload["medications"]
 
 
 def test_nans_to_nones():

--- a/tests/web/test_presenters.py
+++ b/tests/web/test_presenters.py
@@ -243,6 +243,6 @@ def test_make_code_to_name(bnf_codes):
         "100103": "Rheumatic disease suppressant drugs",
         "1001030": "Rheumatic disease suppressant drugs",
         "1001030U0": "Methotrexate",
-        "1001030U0_AB": "Methotrexate 2.5mg tablets (branded and generic)",
-        "1001030U0_AC": "Methotrexate 10mg tablets (branded and generic)",
+        "1001030U0_AB": "Methotrexate 2.5mg tablets",
+        "1001030U0_AC": "Methotrexate 10mg tablets",
     }


### PR DESCRIPTION
This PR makes the necessary changes to the API so that a dm+d query builder has all the metadata it needs.  I've taken the opportunity to tweak the implementation of `BNFCode.strength_and_formulation_name`.