### PR TITLE
Query by form & route separately in YAML measures

### DIFF
--- a/measure_definitions/penicillin-capsules.yaml
+++ b/measure_definitions/penicillin-capsules.yaml
@@ -1,6 +1,6 @@
 metadata:
-  title: Broad spectrum penicillins (capsules)
-  why_it_matters: This is a demo measure which filters by form_route
+  title: Broad spectrum penicillins (capsules.*)
+  why_it_matters: This is a demo measure which filters by forms
   tags:
     - demo
 output:
@@ -8,8 +8,8 @@ output:
     denominator: list_size
 queries:
     - numerator:
-        form_routes:
-          - capsule.oral
+        forms:
+          - capsule
         bnf_codes:
             included:
                 - "0501013"

--- a/measure_definitions/penicillin-oral.yaml
+++ b/measure_definitions/penicillin-oral.yaml
@@ -1,0 +1,15 @@
+metadata:
+  title: Broad spectrum penicillins (*.oral)
+  why_it_matters: This is a demo measure which filters by route
+  tags:
+    - demo
+output:
+    numerator: items
+    denominator: list_size
+queries:
+    - numerator:
+        routes:
+          - oral
+        bnf_codes:
+            included:
+                - "0501013"

--- a/measure_definitions/penicillin-tablet-oral-2.yaml
+++ b/measure_definitions/penicillin-tablet-oral-2.yaml
@@ -1,0 +1,18 @@
+metadata:
+  title: Broad spectrum penicillins (tablet.oral)
+  why_it_matters: This is a demo measure which filters by form & route
+  tags:
+    - demo
+output:
+    numerator: items
+    denominator: list_size
+queries:
+    - numerator:
+        # These are ANDed together, so this will match only `tablet.oral`
+        forms:
+          - tablet
+        routes:
+          - oral
+        bnf_codes:
+            included:
+                - "0501013"

--- a/measure_definitions/penicillin-tablet-oral.yaml
+++ b/measure_definitions/penicillin-tablet-oral.yaml
@@ -1,5 +1,5 @@
 metadata:
-  title: Broad spectrum penicillins (tablets)
+  title: Broad spectrum penicillins (tablet.oral)
   why_it_matters: This is a demo measure which filters by form_route
   tags:
     - demo

--- a/measure_definitions/penicillin-tablet.yaml
+++ b/measure_definitions/penicillin-tablet.yaml
@@ -1,0 +1,15 @@
+metadata:
+  title: Broad spectrum penicillins (tablet.*)
+  why_it_matters: This is a demo measure which filters by form
+  tags:
+    - demo
+output:
+    numerator: items
+    denominator: list_size
+queries:
+    - numerator:
+        forms:
+          - tablet
+        bnf_codes:
+            included:
+                - "0501013"

--- a/openprescribing/data/bnf_query.py
+++ b/openprescribing/data/bnf_query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 from functools import reduce
+from operator import and_
 
 from django.db.models import Q
 
@@ -22,6 +23,30 @@ def _get_bnf_codes_for_form_route_ids(form_route_ids):
             """
         )
         return [x[0] for x in results.fetchall()]
+
+
+def _get_form_route_ids_for_forms_and_routes(form_routes, forms, routes):
+    query = Q()
+    if form_routes:
+        assert not routes and not forms, (
+            "We do not currently support mixing form_routes with routes / forms individually"
+        )
+        query = Q(descr__in=form_routes)
+    else:
+        conditions = []
+        if routes:
+            for route in routes:
+                conditions.append(Q(descr__endswith=f".{route}"))
+        if forms:
+            for form in forms:
+                conditions.append(Q(descr__startswith=f"{form}."))
+        if conditions:
+            query = reduce(and_, conditions)
+
+    form_route_ids = [
+        str(form_route.cd) for form_route in OntFormRoute.objects.filter(query)
+    ]
+    return form_route_ids
 
 
 @dataclass(frozen=True)
@@ -76,11 +101,12 @@ class BNFQuery:
 
         product_type = query_dict.get("product_type", cls.PRODUCT_TYPE_DEFAULT)
 
-        form_routes = query_dict.get("form_routes", [])
-        form_route_ids = [
-            str(form_route.cd)
-            for form_route in OntFormRoute.objects.filter(descr__in=form_routes)
-        ]
+        form_route_ids = _get_form_route_ids_for_forms_and_routes(
+            query_dict.get("form_routes", []),
+            query_dict.get("forms", []),
+            query_dict.get("routes", []),
+        )
+
         return cls(
             terms,
             ProductType(product_type),

--- a/tests/data/test_bnf_query.py
+++ b/tests/data/test_bnf_query.py
@@ -1,6 +1,10 @@
 import pytest
 
-from openprescribing.data.bnf_query import BNFQuery, ProductType
+from openprescribing.data.bnf_query import (
+    BNFQuery,
+    ProductType,
+    _get_form_route_ids_for_forms_and_routes,
+)
 from openprescribing.data.models import BNFCode
 from tests.utils.ingest_utils import ingest_dmd_bnf_map_data, ingest_dmd_data
 
@@ -208,3 +212,38 @@ def test_from_dict_form_route(rxdb, settings, tmp_path):
     }
     query = BNFQuery.from_dict(test_dict)
     assert query.to_dict() == test_dict
+
+
+@pytest.mark.django_db(databases=["data"], transaction=True)
+def test_from_dict_separate_form_route(rxdb, settings, tmp_path):
+    rxdb.ingest([{}])
+    ingest_dmd_data(settings, tmp_path)
+
+    test_dict = {
+        "bnf_codes": {
+            "included": ["0203020C0AAAAAA"],
+        },
+        "forms": ["solutioninjection"],
+        "routes": ["intravenous"],
+    }
+    query = BNFQuery.from_dict(test_dict)
+    expected_dict = {
+        "bnf_codes": {
+            "included": ["0203020C0AAAAAA"],
+        },
+        "form_routes": ["solutioninjection.intravenous"],
+    }
+    assert query.to_dict() == expected_dict
+
+
+@pytest.mark.django_db(databases=["data"], transaction=True)
+def test_get_form_route_ids_for_forms_and_routes(rxdb, settings, tmp_path):
+    rxdb.ingest([{}])
+    ingest_dmd_data(settings, tmp_path)
+
+    route_ids = _get_form_route_ids_for_forms_and_routes(
+        form_routes=[], forms=["tablet"], routes=["oral"]
+    )
+    expected_route_ids = ["1"]
+
+    assert route_ids == expected_route_ids


### PR DESCRIPTION
* allows e.g. 
```
forms:
  - tablet
routes:
  - oral
```
which does the same thing as 
```
form_routes:
  - tablet.oral
```

* Nb. Converting from a dict to an Analysis & back to a dict will revert a wildcard search to an instantiated list of form_routes. I think this ok for now, I think the list of form_routes doesn't change often. This will not affect the use of measures as designed, it would only affect auto-generated YAML files in a future interface that allows "save as measure" (producing a codelist rot type scenario).
