### PR TITLE
YAML search by dm+d ingredients

### DIFF
--- a/measure_definitions/vitamin-d.yaml
+++ b/measure_definitions/vitamin-d.yaml
@@ -1,0 +1,12 @@
+metadata:
+  title: DRAFT Vitamin D
+  why_it_matters: This is a partial implementation of the previous Vitamin D measure
+  tags:
+    - demo
+output:
+    numerator: items
+    denominator: list_size
+queries:
+    - numerator:
+        ingredient_ids:
+          - 18414002

--- a/openprescribing/data/bnf_query.py
+++ b/openprescribing/data/bnf_query.py
@@ -85,7 +85,11 @@ class BNFQuery:
     def from_params(cls, field, params):
         """Build a BNFQuery from URL query parameters for a field."""
 
-        raw_terms = tuple(params[f"{field}_codes"].split(","))
+        if params.get(f"{field}_codes", ""):
+            raw_terms = tuple(params[f"{field}_codes"].split(","))
+        else:
+            raw_terms = ()
+
         product_type = params.get(f"{field}_product_type", cls.PRODUCT_TYPE_DEFAULT)
 
         if ids := params.get(f"{field}_form_route_ids"):
@@ -107,7 +111,7 @@ class BNFQuery:
 
     @classmethod
     def from_dict(cls, query_dict):
-        bnf_codes_dict = query_dict["bnf_codes"]
+        bnf_codes_dict = query_dict.get("bnf_codes", {"included": [], "excluded": []})
         included_terms = tuple(
             [Term.create(rt, False) for rt in bnf_codes_dict["included"]]
         )

--- a/openprescribing/data/bnf_query.py
+++ b/openprescribing/data/bnf_query.py
@@ -131,10 +131,13 @@ class BNFQuery:
             query_dict.get("routes", []),
         )
 
+        ingredient_ids = tuple(str(i) for i in query_dict.get("ingredient_ids", []))
+
         return cls(
             terms,
             ProductType(product_type),
             form_route_ids=form_route_ids,
+            ingredient_ids=ingredient_ids,
         )
 
     def to_dict(self):
@@ -154,6 +157,8 @@ class BNFQuery:
                     cd__in=self.form_route_ids
                 )
             ]
+        if self.ingredient_ids:
+            bnf_query_dict["ingredient_ids"] = list(self.ingredient_ids)
 
         return bnf_query_dict
 

--- a/tests/data/test_analysis.py
+++ b/tests/data/test_analysis.py
@@ -128,3 +128,21 @@ def test_from_dict_numerator_only():
     }
     analysis = Analysis.from_dict(analysis_dict)
     assert analysis.to_dict() == analysis_dict
+
+
+@pytest.mark.django_db(databases=["data"])
+def test_from_dict_ingredients():
+    analysis_dict = {
+        "queries": [
+            {
+                "numerator": {
+                    "bnf_codes": {
+                        "included": ["01"],
+                    },
+                    "ingredient_ids": ["01"],
+                },
+            }
+        ],
+    }
+    analysis = Analysis.from_dict(analysis_dict)
+    assert analysis.to_dict() == analysis_dict

--- a/tests/data/test_bnf_query.py
+++ b/tests/data/test_bnf_query.py
@@ -299,3 +299,15 @@ def test_get_form_route_ids_for_forms_and_routes(rxdb, settings, tmp_path):
     expected_route_ids = ["1"]
 
     assert route_ids == expected_route_ids
+
+
+@pytest.mark.django_db(databases=["data"])
+def test_from_dict_ingredient():
+    test_dict = {
+        "ingredient_ids": ["53034005"],
+    }
+
+    query = BNFQuery.from_dict(test_dict)
+    computed_dict = query.to_dict()
+
+    assert computed_dict["ingredient_ids"] == ["53034005"]

--- a/tests/data/test_bnf_query.py
+++ b/tests/data/test_bnf_query.py
@@ -191,6 +191,13 @@ def test_from_params_with_form_route_ids_key_not_val():
     assert query.form_route_ids == ()
 
 
+def test_from_params_ingredients():
+    query = BNFQuery.from_params("ntr", {"ntr_ingredient_ids": "01"})
+    assert query == BNFQuery.build(
+        [], BNFQuery.PRODUCT_TYPE_DEFAULT, ingredient_ids=["01"]
+    )
+
+
 def test_to_params():
     query = BNFQuery.build(["01", "-0101"], ProductType.GENERIC)
     assert query.to_params("ntr") == {


### PR DESCRIPTION
* support searching/filtering by `ingredient_ids`
* these are DM+D ids as per the `isid` column in the `ing` table
* also some tweaks to allow for a query which does not search by `bnf_codes`
* an example measure, based on an OPv1 measure
