### PR TITLE
Change `project.name` and `project.description`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "repo-template"
+name = "openprescribing"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "openprescribing"
 version = "0.1.0"
-description = "Add your description here"
+description = "A beta version of a new OpenPrescribing"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -570,6 +570,77 @@ wheels = [
 ]
 
 [[package]]
+name = "openprescribing"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "altair" },
+    { name = "beautifulsoup4" },
+    { name = "django" },
+    { name = "duckdb" },
+    { name = "gunicorn" },
+    { name = "html5lib" },
+    { name = "markdown" },
+    { name = "numpy" },
+    { name = "openpyxl" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-sdk" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "scipy" },
+    { name = "whitenoise" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "coverage" },
+    { name = "playwright" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-django" },
+    { name = "pytest-freezer" },
+    { name = "pytest-playwright" },
+    { name = "responses" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "altair", specifier = ">=6.0.0" },
+    { name = "beautifulsoup4", specifier = ">=4.14.2" },
+    { name = "django", specifier = ">=5.2.7" },
+    { name = "duckdb", specifier = ">=1.4.2" },
+    { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "html5lib", specifier = ">=1.1" },
+    { name = "markdown", specifier = ">=3.10.2" },
+    { name = "numpy", specifier = ">=2.3.4" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.38.0" },
+    { name = "opentelemetry-instrumentation-django", specifier = ">=0.59b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.38.0" },
+    { name = "pyarrow", specifier = ">=22.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "requests", specifier = ">=2.32.5" },
+    { name = "scipy", specifier = ">=1.16.2" },
+    { name = "whitenoise", specifier = ">=6.11.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "coverage", specifier = ">=7.10.6" },
+    { name = "playwright", specifier = ">=1.56.0" },
+    { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-django", specifier = ">=4.11.1" },
+    { name = "pytest-freezer", specifier = ">=0.4.9" },
+    { name = "pytest-playwright", specifier = ">=0.7.1" },
+    { name = "responses", specifier = ">=0.25.8" },
+    { name = "ruff", specifier = ">=0.12.11" },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1005,77 +1076,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
-]
-
-[[package]]
-name = "repo-template"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "altair" },
-    { name = "beautifulsoup4" },
-    { name = "django" },
-    { name = "duckdb" },
-    { name = "gunicorn" },
-    { name = "html5lib" },
-    { name = "markdown" },
-    { name = "numpy" },
-    { name = "openpyxl" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-django" },
-    { name = "opentelemetry-sdk" },
-    { name = "pyarrow" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "scipy" },
-    { name = "whitenoise" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "coverage" },
-    { name = "playwright" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-django" },
-    { name = "pytest-freezer" },
-    { name = "pytest-playwright" },
-    { name = "responses" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "altair", specifier = ">=6.0.0" },
-    { name = "beautifulsoup4", specifier = ">=4.14.2" },
-    { name = "django", specifier = ">=5.2.7" },
-    { name = "duckdb", specifier = ">=1.4.2" },
-    { name = "gunicorn", specifier = ">=23.0.0" },
-    { name = "html5lib", specifier = ">=1.1" },
-    { name = "markdown", specifier = ">=3.10.2" },
-    { name = "numpy", specifier = ">=2.3.4" },
-    { name = "openpyxl", specifier = ">=3.1.5" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.38.0" },
-    { name = "opentelemetry-instrumentation-django", specifier = ">=0.59b0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.38.0" },
-    { name = "pyarrow", specifier = ">=22.0.0" },
-    { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "requests", specifier = ">=2.32.5" },
-    { name = "scipy", specifier = ">=1.16.2" },
-    { name = "whitenoise", specifier = ">=6.11.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "coverage", specifier = ">=7.10.6" },
-    { name = "playwright", specifier = ">=1.56.0" },
-    { name = "pre-commit", specifier = ">=4.3.0" },
-    { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-django", specifier = ">=4.11.1" },
-    { name = "pytest-freezer", specifier = ">=0.4.9" },
-    { name = "pytest-playwright", specifier = ">=0.7.1" },
-    { name = "responses", specifier = ">=0.25.8" },
-    { name = "ruff", specifier = ">=0.12.11" },
 ]
 
 [[package]]


### PR DESCRIPTION
Change `project.name` from that given in repo-template to one that's more meaningful. Similarly, `project.description`. This is a small improvement that means a command like this:

```
uv tree --invert  --package django
```

Gives output like this:

```
django v6.0.4
└── openprescribing v0.1.0
```

Rather than this:

```
django v6.0.4
└── repo-template v0.1.0
```