### PR TITLE
Improve view test isolation

### DIFF
--- a/openprescribing/config/settings.py
+++ b/openprescribing/config/settings.py
@@ -125,6 +125,8 @@ SQLITE_DATABASE = DATA_DIR / "data.sqlite"
 # database in tests.
 TEST_SQLITE_DATABASE = DATA_DIR / "test-data.sqlite"
 
+MEASURE_DEFINITIONS_PATH = BASE_DIR / "measure_definitions"
+
 
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases

--- a/openprescribing/data/measures/measures.py
+++ b/openprescribing/data/measures/measures.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-
+from django.conf import settings
 from strictyaml import (
     Any,
     Int,
@@ -11,9 +10,6 @@ from strictyaml import (
     YAMLValidationError,
     load,
 )
-
-
-MEASURE_DEFINITIONS_PATH = Path(__file__).parents[3] / "measure_definitions"
 
 
 class MeasureValidationError(Exception):
@@ -28,8 +24,8 @@ class MeasureValidationError(Exception):
         )
 
 
-def load_measure(measure_name, measures_path=MEASURE_DEFINITIONS_PATH):
-    with open(measures_path / f"{measure_name}.yaml") as f:
+def load_measure(measure_name):
+    with open(settings.MEASURE_DEFINITIONS_PATH / f"{measure_name}.yaml") as f:
         try:
             measure_yaml = load(f.read(), schema())
         except YAMLValidationError as e:
@@ -41,7 +37,7 @@ def load_measure(measure_name, measures_path=MEASURE_DEFINITIONS_PATH):
 
 
 def all_measure_details():
-    measure_names = [f.stem for f in MEASURE_DEFINITIONS_PATH.iterdir()]
+    measure_names = [f.stem for f in settings.MEASURE_DEFINITIONS_PATH.iterdir()]
     measure_details = []
     for f in measure_names:
         measure = load_measure(f)

--- a/tests/data/measures/test_measures.py
+++ b/tests/data/measures/test_measures.py
@@ -49,9 +49,8 @@ def test_load_measure():
     }
 
 
-def test_load_measure_validation_fail():
+def test_load_measure_validation_fail(settings):
+    settings.MEASURE_DEFINITIONS_PATH = Path(__file__).parent / "fixtures"
     with pytest.raises(measures.MeasureValidationError) as excinfo:
-        load_measure(
-            "invalid-measure", measures_path=Path(__file__).parent / "fixtures"
-        )
+        load_measure("invalid-measure")
     assert "'invalid-measure' failed to validate" in str(excinfo.value)

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -143,8 +143,7 @@ queries:
           - "0501013"
 
 """
-    with open(tmp_path / "test-measure.yaml", "w", encoding="utf-8") as f:
-        f.write(test_yaml)
+    (tmp_path / "test-measure.yaml").write_text(test_yaml)
     settings.MEASURE_DEFINITIONS_PATH = tmp_path
 
     rsp = client.get("/measures/")

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -126,9 +126,29 @@ def test_feedback_comment_rejects_missing_session(client):
 
 
 @pytest.mark.django_db(databases=["data"])
-def test_measure(client, sample_data):
+def test_measure(client, sample_data, tmp_path, settings):
+    test_yaml = """
+metadata:
+  title: test title
+  why_it_matters: This is a demo measure
+  tags:
+    - demo
+output:
+  numerator: items
+  denominator: list_size
+queries:
+  - numerator:
+      bnf_codes:
+        included:
+          - "0501013"
+
+"""
+    with open(tmp_path / "test-measure.yaml", "w", encoding="utf-8") as f:
+        f.write(test_yaml)
+    settings.MEASURE_DEFINITIONS_PATH = tmp_path
+
     rsp = client.get("/measures/")
     assert rsp.status_code == 200
 
-    rsp = client.get("/measures/detemir/")
+    rsp = client.get("/measures/test-measure/")
     assert rsp.status_code == 200


### PR DESCRIPTION
* load a sample yaml, rather than the actual yaml files
* previously this test would fail if a clinical informatitian commited
  a measure that failed validation, which would be confusing for them
* we now have a separate test which will catch invalid measures
