### PR TITLE
Raise ValueError for invalid form_routes

### DIFF
--- a/openprescribing/data/bnf_query.py
+++ b/openprescribing/data/bnf_query.py
@@ -46,6 +46,12 @@ def _get_form_route_ids_for_forms_and_routes(form_routes, forms, routes):
     form_route_ids = [
         str(form_route.cd) for form_route in OntFormRoute.objects.filter(query)
     ]
+
+    if not form_route_ids and (form_routes or routes or forms):
+        raise ValueError(
+            f"No matching form_routes for form_routes={form_routes}, routes={routes}, forms={forms}"
+        )
+
     return form_route_ids
 
 

--- a/tests/data/test_bnf_query.py
+++ b/tests/data/test_bnf_query.py
@@ -323,6 +323,27 @@ def test_get_form_route_ids_for_forms_and_routes(rxdb, settings, tmp_path):
     assert route_ids == expected_route_ids
 
 
+@pytest.mark.django_db(databases=["data"], transaction=True)
+def test_get_form_route_ids_for_invalid_form_routes(rxdb, settings, tmp_path):
+    rxdb.ingest([{}])
+    ingest_dmd_data(settings, tmp_path)
+
+    with pytest.raises(ValueError):
+        _get_form_route_ids_for_forms_and_routes(
+            form_routes=[], forms=["unicorn"], routes=[]
+        )
+
+    with pytest.raises(ValueError):
+        _get_form_route_ids_for_forms_and_routes(
+            form_routes=["unicorn.nasal"], forms=[], routes=[]
+        )
+
+    with pytest.raises(ValueError):
+        _get_form_route_ids_for_forms_and_routes(
+            form_routes=[], forms=[], routes=["interstellar"]
+        )
+
+
 @pytest.mark.django_db(databases=["data"])
 def test_from_dict_ingredient():
     test_dict = {


### PR DESCRIPTION
* throw an error if there are no matching form_routes, instead of doing a wildcard search
* this only applies to YAML measures - which we are currently grooming carefully - and I would hope that this kind of error would be noticed by someone developing a measure, but we should check it!
