### PR TITLE
Fix biome warning

### DIFF
--- a/openprescribing/web/static/js/build-analysis/render.js
+++ b/openprescribing/web/static/js/build-analysis/render.js
@@ -40,12 +40,7 @@ export function renderAddFilterOptions(panel) {
 export function renderSummary(sectionsByPrefix, panels, metadata, templates) {
   // Render the active filters for each panel into the summary tab.
   panels.forEach((panel) => {
-    renderSummarySection(
-      sectionsByPrefix.get(panel.prefix),
-      panel,
-      metadata,
-      templates,
-    );
+    renderSummarySection(sectionsByPrefix.get(panel.prefix), panel, templates);
   });
 }
 
@@ -63,7 +58,7 @@ function getActiveFilterControlCount(panel) {
   return Object.keys(panel.dropdowns.getAllSelected()).length;
 }
 
-function renderSummarySection(sectionEl, panel, metadata, templates) {
+function renderSummarySection(sectionEl, panel, templates) {
   // Render given panel's active filters into its summary section.
   const selectedNamesByKey = panel.dropdowns.getAllSelectedNames();
   const activeFilters = FILTER_DEFINITIONS.flatMap((definition) =>


### PR DESCRIPTION
```
> biome check

openprescribing/web/static/js/build-analysis/render.js:66:49 lint/correctness/noUnusedFunctionParameters  FIXABLE  ━━━━━━━━━━

  ! This parameter is unused.
  
    64 │ }
    65 │ 
  > 66 │ function renderSummarySection(sectionEl, panel, metadata, templates) {
       │                                                 ^^^^^^^^
    67 │   // Render given panel's active filters into its summary section.
    68 │   const selectedNamesByKey = panel.dropdowns.getAllSelectedNames();
  
  i Unused parameters might be the result of an incomplete refactoring.
  
  i Unsafe fix: If this is intentional, prepend metadata with an underscore.
  
     64  64 │   }
     65  65 │   
     66     │ - function·renderSummarySection(sectionEl,·panel,·metadata,·templates)·{
         66 │ + function·renderSummarySection(sectionEl,·panel,·_metadata,·templates)·{
     67  67 │     // Render given panel's active filters into its summary section.
     68  68 │     const selectedNamesByKey = panel.dropdowns.getAllSelectedNames();
  

Checked 15 files in 31ms. No fixes applied.
Found 1 warning.

```
