### PR TITLE
Remove unnecessary uses of data database pytest mark

### DIFF
--- a/tests/data/ingestors/test_ods.py
+++ b/tests/data/ingestors/test_ods.py
@@ -166,7 +166,6 @@ def test_ods_ingest(tmp_path, settings):
 @pytest.mark.parametrize(
     "frozen_date,expected_pcn", [("2026-03-20", "U93165"), ("2026-04-20", "U25891")]
 )
-@pytest.mark.django_db(databases=["data"])
 def test_ods_ingest_multiple_pcns(rxdb, tmp_path, settings, frozen_date, expected_pcn):
     with freeze_time(frozen_date):
         duckdb_view_from_json_file(
@@ -182,7 +181,6 @@ def test_ods_ingest_multiple_pcns(rxdb, tmp_path, settings, frozen_date, expecte
 
 
 @freeze_time("2026-03-20")
-@pytest.mark.django_db(databases=["data"])
 def test_ods_ingest_multiple_pcns_missing_opEndDate(rxdb, tmp_path, settings):
     duckdb_view_from_json_file(
         rxdb.conn,

--- a/tests/data/measures/test_measures.py
+++ b/tests/data/measures/test_measures.py
@@ -57,7 +57,6 @@ def test_load_measure_strictyaml_validation_invalid(settings):
     assert "'invalid-measure-queries' failed to validate" in str(excinfo.value)
 
 
-@pytest.mark.django_db(databases=["data"], transaction=True)
 def test_load_measure_pydantic_validation_valid_form_route(rxdb, settings, tmp_path):
     rxdb.ingest([{}])
     ingest_dmd_data(settings, tmp_path)
@@ -77,7 +76,6 @@ def test_load_measure_pydantic_validation_valid_form_route(rxdb, settings, tmp_p
         "invalid-measure-product-type",
     ],
 )
-@pytest.mark.django_db(databases=["data"], transaction=True)
 def test_load_measure_pydantic_validation_invalid_measure(
     rxdb, settings, tmp_path, measure_name
 ):

--- a/tests/data/queries/test_get_org_date_ratio_matrix.py
+++ b/tests/data/queries/test_get_org_date_ratio_matrix.py
@@ -1,5 +1,3 @@
-import pytest
-
 from openprescribing.data.analysis import Analysis
 from openprescribing.data.bnf_query import BNFQuery
 from openprescribing.data.list_size_query import ListSizeQuery
@@ -9,7 +7,6 @@ from tests.utils.rxdb_utils import assert_approx_equal
 from .alternative_implementations import get_org_date_ratio_matrix_alternative
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_get_org_date_ratio_matrix_prescribing_vs_list_size(rxdb, sample_data):
     analysis = Analysis(
         ntr_query=BNFQuery(bnf_codes=["1001030U0AAABAB"]),
@@ -25,7 +22,6 @@ def test_get_org_date_ratio_matrix_prescribing_vs_list_size(rxdb, sample_data):
     assert_approx_equal(odm, expected_odm)
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_get_org_date_ratio_matrix_prescribing_vs_prescribing(rxdb, sample_data):
     analysis = Analysis(
         ntr_query=BNFQuery(bnf_codes=["1001030U0AAABAB"]),

--- a/tests/data/queries/test_get_practice_date_matrix.py
+++ b/tests/data/queries/test_get_practice_date_matrix.py
@@ -1,7 +1,5 @@
 from datetime import date
 
-import pytest
-
 from openprescribing.data.bnf_query import BNFQuery
 from openprescribing.data.list_size_query import ListSizeQuery
 from openprescribing.data.models import BNFCode
@@ -11,7 +9,6 @@ from tests.utils.rxdb_utils import assert_approx_equal
 from .alternative_implementations import get_practice_date_matrix_alternative
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_get_practice_date_matrix_spot_check(rxdb):
     BNFCode.objects.create(code="1001030U0AAABAB", level=7)
     rxdb.ingest(
@@ -84,7 +81,6 @@ def test_get_practice_date_matrix_spot_check(rxdb):
     ]
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_get_practice_date_matrix_for_bnf_query(rxdb, sample_data):
     query = BNFQuery(bnf_codes=["1001030U0AAABAB"])
 
@@ -98,7 +94,6 @@ def test_get_practice_date_matrix_for_bnf_query(rxdb, sample_data):
     assert_approx_equal(pdm, expected_pdm)
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_get_practice_date_matrix_for_bnf_query_no_matching_codes(rxdb, sample_data):
     invalid_bnf_code = "999999999"
     query = BNFQuery(bnf_codes=[invalid_bnf_code])
@@ -113,7 +108,6 @@ def test_get_practice_date_matrix_for_bnf_query_no_matching_codes(rxdb, sample_d
     assert_approx_equal(pdm, expected_pdm)
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_get_practice_date_matrix_for_list_sizes(rxdb, sample_data):
     query = ListSizeQuery()
 

--- a/tests/data/rxdb/test_create_views.py
+++ b/tests/data/rxdb/test_create_views.py
@@ -1,7 +1,3 @@
-import pytest
-
-
-@pytest.mark.django_db(databases=["data"], transaction=True)
 def test_medications(rxdb, dmd_data):
 
     # Confirm that we can query the medications table.

--- a/tests/test_measure_definitions.py
+++ b/tests/test_measure_definitions.py
@@ -1,10 +1,7 @@
-import pytest
-
 from openprescribing.data.measures import all_measure_details, load_measure
 from tests.utils.ingest_utils import ingest_dmd_data
 
 
-@pytest.mark.django_db(databases=["data"], transaction=True)
 def test_load_all_measures(rxdb, settings, tmp_path):
     rxdb.ingest([{}])
     ingest_dmd_data(settings, tmp_path)

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -4,7 +4,6 @@ from openprescribing.web import api
 from tests.utils.ingest_utils import ingest_dmd_bnf_map_data, ingest_dmd_data
 
 
-@pytest.mark.django_db(databases=["data"])
 @pytest.mark.parametrize(
     "params, expected_last_value",
     [
@@ -24,7 +23,6 @@ def test_prescribing_all_orgs(client, sample_data, params, expected_last_value):
     assert payload["all_orgs"][-1]["value"] == pytest.approx(expected_last_value, 0.001)
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_prescribing_deciles(client, sample_data):
     rsp = client.get("/api/prescribing-deciles/?ntr_bnf_codes=1001030U0")
     payload = rsp.json()
@@ -33,7 +31,6 @@ def test_prescribing_deciles(client, sample_data):
     assert payload["org"] == []
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_prescribing_deciles_with_practice(client, sample_data):
     rsp = client.get("/api/prescribing-deciles/?ntr_bnf_codes=1001030U0&org_id=PRA00")
     payload = rsp.json()
@@ -42,7 +39,6 @@ def test_prescribing_deciles_with_practice(client, sample_data):
     assert payload["org"][-1]["value"] == pytest.approx(51.94, 0.001)
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_prescribing_deciles_with_exclusion(client, sample_data):
     rsp = client.get(
         "/api/prescribing-deciles/?ntr_bnf_codes=1001030U0&ntr_bnf_codes_excluded=1001030U0AAABAB"
@@ -53,7 +49,6 @@ def test_prescribing_deciles_with_exclusion(client, sample_data):
     assert payload["org"] == []
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_prescribing_deciles_with_denominator(client, sample_data):
     rsp = client.get(
         "/api/prescribing-deciles/?ntr_bnf_codes=1001030U0AA&dtr_bnf_codes=1001030U0"
@@ -64,7 +59,6 @@ def test_prescribing_deciles_with_denominator(client, sample_data):
     assert payload["org"] == []
 
 
-@pytest.mark.django_db(databases=["data"], transaction=True)
 def test_metadata_medications(client, rxdb, settings, tmp_path):
     rxdb.ingest([{"bnf_code": "1106000X0AAA4A4"}])
     ingest_dmd_data(settings, tmp_path)
@@ -124,7 +118,6 @@ def test_metadata_dmd(client, settings, tmp_path):
     ]
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_metadata_bnf(client, bnf_codes):
     rsp = client.get("/api/metadata/bnf/")
     payload = rsp.json()

--- a/tests/web/test_presenters.py
+++ b/tests/web/test_presenters.py
@@ -10,7 +10,6 @@ from openprescribing.web.presenters import (
 )
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_make_bnf_tree(bnf_codes):
     codes = BNFCode.objects.all()
 
@@ -76,7 +75,6 @@ def test_make_bnf_tree(bnf_codes):
     ]
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_make_bnf_table_with_generic_products(bnf_codes):
     code = "1001030U0"
     products = BNFCode.objects.filter(
@@ -110,7 +108,6 @@ def test_make_bnf_table_with_generic_products(bnf_codes):
     ]
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_make_bnf_table_with_no_generic_products(bnf_codes):
     code = "0601060D0"
     products = BNFCode.objects.filter(
@@ -198,7 +195,6 @@ def test_make_bnf_table_with_no_generic_products(bnf_codes):
         ),
     ],
 )
-@pytest.mark.django_db(databases=["data"])
 def test_make_ntr_dtr_intersection_table(
     bnf_codes, ntr_codes, ntr_product_type, dtr_codes, dtr_product_type, expected
 ):
@@ -221,7 +217,6 @@ def test_make_ntr_dtr_intersection_table(
     assert actual["has_denominators"] is expected["has_denominators"]
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_make_code_to_name(bnf_codes):
     codes = BNFCode.objects.filter(code__startswith="10")
     assert make_code_to_name(codes) == {

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -7,7 +7,6 @@ from openprescribing.web.analysis_presentation import ChartType
 from openprescribing.web.models import Feedback
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_analysis(client, sample_data):
     rsp = client.get("")
     assert rsp.status_code == 200
@@ -62,7 +61,6 @@ def test_analysis(client, sample_data):
     assert rsp.context["analysis_presentation"].chart_type == ChartType.DECILES
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_analysis_build(client, sample_data):
     rsp = client.get("/analysis/build/")
     assert rsp.status_code == 200
@@ -71,19 +69,16 @@ def test_analysis_build(client, sample_data):
     assert rsp.status_code == 200
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_bnf_tree(client, bnf_codes):
     rsp = client.get("/bnf/")
     assert rsp.status_code == 200
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_bnf_table_with_generic_products(client, bnf_codes):
     rsp = client.get("/bnf/1001030U0/")
     assert rsp.status_code == 200
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_bnf_table_with_no_generic_products(client, bnf_codes):
     rsp = client.get("/bnf/0601060D0/")
     assert rsp.status_code == 200
@@ -129,7 +124,6 @@ def test_feedback_comment_rejects_missing_session(client):
     assert feedback.comment == ""
 
 
-@pytest.mark.django_db(databases=["data"])
 def test_measure(client, sample_data, tmp_path, settings):
     test_yaml = """
 metadata:


### PR DESCRIPTION
* anything that uses the fixtures `bnf_codes`, `rxdb` or `sample_data` will now have the appropriate mark applied
* in some cases the explicit mark could be misleading (e.g. if it does not have transaction set, but the automatic mark does)