### PR TITLE
Replace deadsnakes with uv

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,34 +41,20 @@ FROM ghcr.io/opensafely-core/base-action:${UBUNTU_VERSION} AS base-python
 # docker clean up that deletes that cache on every apt install
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
 
-# use deadsnakes ppa to install a fully working base python installation
-# see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
-# use space efficient utility from base image
-RUN --mount=type=cache,target=/var/cache/apt <<'EOF'
-UBUNTU_CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-KEY_PATH=/usr/share/keyrings/deadsnakes.asc
-KEY_URL='https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776'
-/usr/lib/apt/apt-helper download-file "$KEY_URL" "$KEY_PATH"
-echo "deb [signed-by=$KEY_PATH] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/deadsnakes-ppa.list
-EOF
-
 # install any additional system dependencies
-# NOTE: ensure .python-version is not excluded in .dockerignore
 RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=bind,source=docker/dependencies.txt,target=/dependencies.txt \
-    --mount=type=bind,source=.python-version,target=/.python-version \
-    /root/docker-apt-install.sh /dependencies.txt "python$(cat /.python-version)"
+    /root/docker-apt-install.sh /dependencies.txt
 
 # uv env var documentation: https://docs.astral.sh/uv/reference/environment/
 # copy files rather than symlink since the cache and the target are on different filesystems
 ENV UV_LINK_MODE=copy
 # compile at installation time, not import time
 ENV UV_COMPILE_BYTECODE=1
-# we are providing python via deadsnakes ppa
-# (as we require dynamic linking of openssl for security reasons)
-ENV UV_PYTHON_DOWNLOADS=never
 # set the directory for the venv
 ENV UV_PROJECT_ENVIRONMENT="/opt/venv"
+# install python to a location that is readable by non-root users
+ENV UV_PYTHON_INSTALL_DIR="/opt/uv/python"
 
 ##################################################
 #
@@ -103,7 +89,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
 COPY --from=uv-cli /uv /uvx /usr/local/bin/
 
 # Install everything in venv for isolation from system python libraries
-RUN uv venv
+RUN --mount=type=bind,source=.python-version,target=/.python-version \
+    uv venv --managed-python --python "$(cat /.python-version)"
 
 # The cache mount means a) /root/.cache is not in the image, and b) it's preserved
 # between docker builds locally, for faster dev rebuild.
@@ -147,6 +134,7 @@ ENV VIRTUAL_ENV=/opt/venv/ \
 # copy venv over from builder image. These will have root:root ownership, but
 # are readable by all.
 COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /opt/uv/python /opt/uv/python
 
 ##################################################
 #


### PR DESCRIPTION
This commit replaces the Python interpreter provided by the deadsnakes PPA with the Python interpreter provided by uv. We're replacing the Python interpreter because a (roughly) four-day outage of ppa.launchpadcontent.net, which hosts the deadsnakes PPA, prevented us from building, and ultimately deploying, images.

Once upon a time, we chose not to use uv's Python interpreter because we feared it could be shipped with an older version of OpenSSL than was available on Ubuntu. However, it actually ships with a newer version. For this reason, and because it's good to have fewer dependencies in the Dockerfile, we're replacing the Python interpreter even though ppa.launchpadcontent.net seems to have recovered.