### PR TITLE
Use dict/JSON to pass the analysis to the API

### DIFF
--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -1,3 +1,4 @@
+import json
 import math
 
 from django.http import JsonResponse as DjangoJsonResponse
@@ -61,7 +62,8 @@ def prescribing_all_orgs(request):
 
 
 def prescribing_deciles(request):
-    analysis = Analysis.from_params(request.GET)
+    analysis = Analysis.from_dict(json.loads(request.GET["analysis"]))
+
     with rxdb.get_cursor() as cursor:
         odm = get_org_date_ratio_matrix(cursor, analysis, date_count=DATE_COUNT)
     org = _get_org(analysis)

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -42,7 +42,8 @@ def _get_org_records(odm, org):
 
 
 def prescribing_all_orgs(request):
-    analysis = Analysis.from_params(request.GET)
+    analysis = Analysis.from_dict(json.loads(request.GET["analysis"]))
+
     with rxdb.get_cursor() as cursor:
         odm = get_org_date_ratio_matrix(cursor, analysis, date_count=DATE_COUNT)
     org = _get_org(analysis)

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -1,3 +1,4 @@
+import json
 from urllib.parse import urlencode
 
 import altair as alt
@@ -42,7 +43,7 @@ def _build_analysis_context(analysis):
                 analysis.ntr_query, None
             )
 
-        url_parameters = urlencode(analysis.to_params(), safe=",")
+        url_parameters = urlencode({"analysis": json.dumps(analysis.to_dict())})
         build_analysis_url = f"{reverse('build-analysis')}?{url_parameters}"
         deciles_api_url = f"{reverse('api_prescribing_deciles')}?{url_parameters}"
         all_orgs_api_url = f"{reverse('api_prescribing_all_orgs')}?{url_parameters}"

--- a/tests/data/test_bnf_query.py
+++ b/tests/data/test_bnf_query.py
@@ -551,6 +551,11 @@ def test_from_params_ingredients():
 
 
 def test_to_params():
+    query = BNFQuery(bnf_codes=["01"])
+    assert query.to_params("ntr") == {"ntr_bnf_codes": "01", "ntr_product_type": "all"}
+
+
+def test_to_params_excluded():
     query = BNFQuery(
         bnf_codes=["01"], bnf_codes_excluded=["0101"], product_type=ProductType.GENERIC
     )

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -7,27 +7,85 @@ from openprescribing.web import api
 from tests.utils.ingest_utils import ingest_dmd_bnf_map_data, ingest_dmd_data
 
 
+def _analysis_dict_to_param(analysis_dict):
+    return urlencode({"analysis": json.dumps(analysis_dict)})
+
+
 @pytest.mark.parametrize(
-    "params, expected_last_value",
+    "analysis_dict, expected_last_value",
     [
-        ("?ntr_bnf_codes=1001030U0", 65.09),
-        ("?ntr_bnf_codes=1001030U0&org_id=PRA00", 68.40),
         (
-            "?ntr_bnf_codes=1001030U0&ntr_bnf_codes_excluded=1001030U0AAABAB",
+            {
+                "queries": [
+                    {
+                        "numerator": {
+                            "bnf_codes": {
+                                "included": ["1001030U0"],
+                            },
+                        },
+                    },
+                ],
+            },
+            65.09,
+        ),
+        (
+            {
+                "queries": [
+                    {
+                        "numerator": {
+                            "bnf_codes": {
+                                "included": ["1001030U0"],
+                            },
+                        },
+                    },
+                ],
+                "org_id": "PRA00",
+            },
+            68.40,
+        ),
+        (
+            {
+                "queries": [
+                    {
+                        "numerator": {
+                            "bnf_codes": {
+                                "included": ["1001030U0"],
+                                "excluded": ["1001030U0AAABAB"],
+                            },
+                        },
+                    },
+                ],
+            },
             59.67,
         ),
-        ("?ntr_bnf_codes=1001030U0AA&dtr_bnf_codes=1001030U0", 27.77),
+        (
+            {
+                "queries": [
+                    {
+                        "numerator": {
+                            "bnf_codes": {
+                                "included": ["1001030U0AA"],
+                            },
+                        },
+                        "denominator": {
+                            "bnf_codes": {
+                                "included": ["1001030U0"],
+                            },
+                        },
+                    },
+                ],
+            },
+            27.77,
+        ),
     ],
 )
-def test_prescribing_all_orgs(client, sample_data, params, expected_last_value):
-    rsp = client.get(f"/api/prescribing-all-orgs/{params}")
+def test_prescribing_all_orgs(client, sample_data, analysis_dict, expected_last_value):
+    rsp = client.get(
+        f"/api/prescribing-all-orgs/?{_analysis_dict_to_param(analysis_dict)}"
+    )
     payload = rsp.json()
     assert rsp.status_code == 200
     assert payload["all_orgs"][-1]["value"] == pytest.approx(expected_last_value, 0.001)
-
-
-def _analysis_dict_to_param(analysis_dict):
-    return urlencode({"analysis": json.dumps(analysis_dict)})
 
 
 def test_prescribing_deciles(client, sample_data):

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -1,3 +1,6 @@
+import json
+from urllib.parse import urlencode
+
 import pytest
 
 from openprescribing.web import api
@@ -23,8 +26,26 @@ def test_prescribing_all_orgs(client, sample_data, params, expected_last_value):
     assert payload["all_orgs"][-1]["value"] == pytest.approx(expected_last_value, 0.001)
 
 
+def _analysis_dict_to_param(analysis_dict):
+    return urlencode({"analysis": json.dumps(analysis_dict)})
+
+
 def test_prescribing_deciles(client, sample_data):
-    rsp = client.get("/api/prescribing-deciles/?ntr_bnf_codes=1001030U0")
+    analysis_dict = {
+        "queries": [
+            {
+                "numerator": {
+                    "bnf_codes": {
+                        "included": ["1001030U0"],
+                    },
+                },
+            },
+        ],
+    }
+    rsp = client.get(
+        f"/api/prescribing-deciles/?{_analysis_dict_to_param(analysis_dict)}"
+    )
+
     payload = rsp.json()
     assert rsp.status_code == 200
     assert payload["deciles"][-1]["value"] == pytest.approx(64.15, 0.001)
@@ -32,7 +53,22 @@ def test_prescribing_deciles(client, sample_data):
 
 
 def test_prescribing_deciles_with_practice(client, sample_data):
-    rsp = client.get("/api/prescribing-deciles/?ntr_bnf_codes=1001030U0&org_id=PRA00")
+    analysis_dict = {
+        "queries": [
+            {
+                "numerator": {
+                    "bnf_codes": {
+                        "included": ["1001030U0"],
+                    },
+                },
+            },
+        ],
+        "org_id": "PRA00",
+    }
+    rsp = client.get(
+        f"/api/prescribing-deciles/?{_analysis_dict_to_param(analysis_dict)}"
+    )
+
     payload = rsp.json()
     assert rsp.status_code == 200
     assert payload["deciles"][-1]["value"] == pytest.approx(66.41, 0.001)
@@ -40,9 +76,22 @@ def test_prescribing_deciles_with_practice(client, sample_data):
 
 
 def test_prescribing_deciles_with_exclusion(client, sample_data):
+    analysis_dict = {
+        "queries": [
+            {
+                "numerator": {
+                    "bnf_codes": {
+                        "included": ["1001030U0"],
+                        "excluded": ["1001030U0AAABAB"],
+                    },
+                },
+            },
+        ],
+    }
     rsp = client.get(
-        "/api/prescribing-deciles/?ntr_bnf_codes=1001030U0&ntr_bnf_codes_excluded=1001030U0AAABAB"
+        f"/api/prescribing-deciles/?{_analysis_dict_to_param(analysis_dict)}"
     )
+
     payload = rsp.json()
     assert rsp.status_code == 200
     assert payload["deciles"][-1]["value"] == pytest.approx(59.07, 0.001)
@@ -50,9 +99,26 @@ def test_prescribing_deciles_with_exclusion(client, sample_data):
 
 
 def test_prescribing_deciles_with_denominator(client, sample_data):
+    analysis_dict = {
+        "queries": [
+            {
+                "numerator": {
+                    "bnf_codes": {
+                        "included": ["1001030U0AA"],
+                    },
+                },
+                "denominator": {
+                    "bnf_codes": {
+                        "included": ["1001030U0"],
+                    },
+                },
+            },
+        ],
+    }
     rsp = client.get(
-        "/api/prescribing-deciles/?ntr_bnf_codes=1001030U0AA&dtr_bnf_codes=1001030U0"
+        f"/api/prescribing-deciles/?{_analysis_dict_to_param(analysis_dict)}"
     )
+
     payload = rsp.json()
     assert rsp.status_code == 200
     assert payload["deciles"][-1]["value"] == pytest.approx(27.14, 0.001)

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -15,7 +15,7 @@ def test_analysis(client, sample_data):
     assert rsp.status_code == 200
     assert (
         rsp.context["prescribing_deciles_url"]
-        == "/api/prescribing-deciles/?ntr_product_type=all&ntr_bnf_codes=1001030U0"
+        == "/api/prescribing-deciles/?analysis=%7B%22queries%22%3A+%5B%7B%22numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0%22%5D%7D%7D%7D%5D%7D"
     )
     assert rsp.context["analysis_presentation"].chart_type == ChartType.DECILES
 
@@ -23,14 +23,14 @@ def test_analysis(client, sample_data):
     assert rsp.status_code == 200
     assert (
         rsp.context["prescribing_deciles_url"]
-        == "/api/prescribing-deciles/?ntr_product_type=all&ntr_bnf_codes=1001030U0&dtr_product_type=all&dtr_bnf_codes=1001"
+        == "/api/prescribing-deciles/?analysis=%7B%22queries%22%3A+%5B%7B%22numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0%22%5D%7D%7D%2C+%22denominator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001%22%5D%7D%7D%7D%5D%7D"
     )
 
     rsp = client.get("?ntr_bnf_codes=1001030U0AAABAB,1001030U0AAABAB")
     assert rsp.status_code == 200
     assert (
         rsp.context["prescribing_deciles_url"]
-        == "/api/prescribing-deciles/?ntr_product_type=all&ntr_bnf_codes=1001030U0AAABAB,1001030U0AAABAB"
+        == "/api/prescribing-deciles/?analysis=%7B%22queries%22%3A+%5B%7B%22numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0AAABAB%22%2C+%221001030U0AAABAB%22%5D%7D%7D%7D%5D%7D"
     )
 
     rsp = client.get(
@@ -39,7 +39,7 @@ def test_analysis(client, sample_data):
     assert rsp.status_code == 200
     assert (
         rsp.context["prescribing_deciles_url"]
-        == "/api/prescribing-deciles/?ntr_product_type=all&ntr_bnf_codes=1001030U0AA&ntr_bnf_codes_excluded=1001030U0AAABAB"
+        == "/api/prescribing-deciles/?analysis=%7B%22queries%22%3A+%5B%7B%22numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0AA%22%5D%2C+%22excluded%22%3A+%5B%221001030U0AAABAB%22%5D%7D%7D%7D%5D%7D"
     )
 
     rsp = client.get(
@@ -48,7 +48,7 @@ def test_analysis(client, sample_data):
     assert rsp.status_code == 200
     assert (
         rsp.context["prescribing_deciles_url"]
-        == "/api/prescribing-deciles/?ntr_product_type=all&ntr_bnf_codes=1001030U0AA&ntr_bnf_codes_excluded=1001030U0AAABAB&org_id=PRA00"
+        == "/api/prescribing-deciles/?analysis=%7B%22queries%22%3A+%5B%7B%22numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0AA%22%5D%2C+%22excluded%22%3A+%5B%221001030U0AAABAB%22%5D%7D%7D%7D%5D%2C+%22org_id%22%3A+%22PRA00%22%7D"
     )
 
     rsp = client.get("?ntr_bnf_codes=1001030U0&chart_type=all-orgs-line")


### PR DESCRIPTION
* as discussed, use JSON/dict instead of params to pass an Analysis from an analysis/measure to the API
* the params format is currently nicely human-readable, but we want to support composite analyses (the sum of multiple queries) and that will be difficult to do with params
* nb. for the time being we will continue to use the params format to pass an analysis from the analysis builder page to the analysis view page. This may change in future though.
