### PR TITLE
Add comments to the prescribing fetcher

### DIFF
--- a/openprescribing/data/fetchers/prescribing.py
+++ b/openprescribing/data/fetchers/prescribing.py
@@ -39,12 +39,17 @@ def fetch_dataset(directory, dataset_id, version_number):
     )
     response_data = response.json()
 
+    # a list of two-tuples, (resource ID, resource filename)
     items_to_fetch = get_items_to_fetch(existing_files, response_data, version_number)
 
     # Any requests we now make will be to fetch new files so we log at INFO level
     http.log = log.info
 
     for item_id, output_filename in items_to_fetch:
+        # We request a resource again because the ZIP URL expires an hour after it's
+        # generated. If we didn't, and used the ZIP URLs in the original request, then
+        # the more resources we fetched, the greater the likelihood of their URLs
+        # expiring.
         item_resp = http.get("action/resource_show", params={"id": item_id})
         zip_url = item_resp.json()["result"]["zip_url"]
         remote_zipped_csv_to_parquet(
@@ -54,28 +59,54 @@ def fetch_dataset(directory, dataset_id, version_number):
 
 
 def get_items_to_fetch(existing_files, response_data, version_number):
+    """
+    Prescribing data are published in monthly batches, three months in arrears. Whilst
+    there may be multiple batches per month, later batches subsume earlier batches. We
+    save batches in files named according to the following pattern:
+
+    prescribing_<batch-date>_v<epd-version-number>_<publication-datetime>.parquet
+
+    <batch-date>
+        The date of the batch. This is always the first of the month.
+
+    <epd-version-number>
+        The version of the English Prescribing Dataset (EPD).
+        Version 3 has SNOMED codes. Version 2 doesn't and is retired.
+
+    <publication-datetime>
+        The date and time the batch was published.
+    """
+
+    # for each batch-date, get the file with the latest publication-datetime
     files_by_date = get_latest_files_by_date(existing_files)
+    # a resource is a published batch
     resources = response_data["result"]["resources"]
 
     to_fetch = []
     already_fetched = 0
     total = 0
+    # We extract the batch-date from the name, so this iterates from earliest to latest
+    # batch-date.
     for item in sorted(resources, key=lambda i: i["name"]):
+        # extract the batch-date
         year_month = re.match(r"^EPD_(?:SNOMED_)?(\d{6})$", item["name"]).group(1)
         date = datetime.date.fromisoformat(f"{year_month}01")
+
+        # extract the publication-datetime
         published_at = datetime.datetime.fromisoformat(
             # Oddly `last_modified` is sometimes null (maybe before the first update?)
             # so we have to use the `created` date
             item["last_modified"] or item["created"]
         )
 
-        # We use the version number to distinguish between the EPD with (v3) and without
-        # (v2) SNOMED codes.
+        # the filename of the resource, if we were to save the resource to a file
         filename = (
             f"prescribing_{date}_v{version_number}_{published_at:%Y-%m-%dT%H%M}.parquet"
         )
 
         if date in files_by_date and files_by_date[date].name >= filename:
+            # We've already fetched a batch with the batch-date and it was published at
+            # the same time as or later than the resource.
             already_fetched += 1
         else:
             to_fetch.append((item["id"], filename))

--- a/openprescribing/data/fetchers/prescribing.py
+++ b/openprescribing/data/fetchers/prescribing.py
@@ -39,12 +39,17 @@ def fetch_dataset(directory, dataset_id, version_number):
     )
     response_data = response.json()
 
+    # a list of two-tuples, (resource ID, resource filename)
     items_to_fetch = get_items_to_fetch(existing_files, response_data, version_number)
 
     # Any requests we now make will be to fetch new files so we log at INFO level
     http.log = log.info
 
     for item_id, output_filename in items_to_fetch:
+        # We request information about each resource because the ZIP URL expires an hour
+        # after it's generated. If we didn't, and used the ZIP URLs in the original
+        # request, then the more resources we fetched, the greater the likelihood of
+        # their URLs expiring.
         item_resp = http.get("action/resource_show", params={"id": item_id})
         zip_url = item_resp.json()["result"]["zip_url"]
         remote_zipped_csv_to_parquet(
@@ -54,28 +59,54 @@ def fetch_dataset(directory, dataset_id, version_number):
 
 
 def get_items_to_fetch(existing_files, response_data, version_number):
+    """
+    Prescribing data are published in monthly releases, three months in arrears. Whilst
+    there may be multiple releases per month, later releases replace earlier releases.
+    We save releases in files named according to the following pattern:
+
+    prescribing_<release-date>_v<epd-version-number>_<publication-datetime>.parquet
+
+    <release-date>
+        The date of the release. This is always the first of the month.
+
+    <epd-version-number>
+        The version of the English Prescribing Dataset (EPD).
+        Version 3 has SNOMED codes. Version 2 doesn't and is retired.
+
+    <publication-datetime>
+        The date and time the release was published.
+    """
+
+    # for each release-date, get the file with the latest publication-datetime
     files_by_date = get_latest_files_by_date(existing_files)
+    # a resource is a published release
     resources = response_data["result"]["resources"]
 
     to_fetch = []
     already_fetched = 0
     total = 0
+    # We extract the release-date from the name, so this iterates from earliest to
+    # latest release-date.
     for item in sorted(resources, key=lambda i: i["name"]):
+        # extract the release-date
         year_month = re.match(r"^EPD_(?:SNOMED_)?(\d{6})$", item["name"]).group(1)
         date = datetime.date.fromisoformat(f"{year_month}01")
+
+        # extract the publication-datetime
         published_at = datetime.datetime.fromisoformat(
             # Oddly `last_modified` is sometimes null (maybe before the first update?)
             # so we have to use the `created` date
             item["last_modified"] or item["created"]
         )
 
-        # We use the version number to distinguish between the EPD with (v3) and without
-        # (v2) SNOMED codes.
+        # the filename of the resource, if we were to save the resource to a file
         filename = (
             f"prescribing_{date}_v{version_number}_{published_at:%Y-%m-%dT%H%M}.parquet"
         )
 
         if date in files_by_date and files_by_date[date].name >= filename:
+            # We've already fetched a release with the release-date and it was published
+            # at the same time as or later than the resource.
             already_fetched += 1
         else:
             to_fetch.append((item["id"], filename))

--- a/openprescribing/data/fetchers/prescribing.py
+++ b/openprescribing/data/fetchers/prescribing.py
@@ -69,8 +69,8 @@ def get_items_to_fetch(existing_files, response_data, version_number):
             item["last_modified"] or item["created"]
         )
 
-        # We use version numbers to distinguish the different structures in which
-        # prescribing data has historically been published.
+        # We use the version number to distinguish between the EPD with (v3) and without
+        # (v2) SNOMED codes.
         filename = (
             f"prescribing_{date}_v{version_number}_{published_at:%Y-%m-%dT%H%M}.parquet"
         )


### PR DESCRIPTION
This is the first (and possibly the only) step towards making the fetcher easier to understand. I spent some time trying to understand it when debugging a missing `zip_url` earlier this week. Rather than let the next person also try to understand it, the next time they have to debug it, I thought I'd add comments.

Ideally, I'd use the comments to refactor the fetcher. I don't have time to do that now, sadly.