### PR TITLE
Revert 0a30369

### DIFF
--- a/openprescribing/data/ingestors/prescribing.py
+++ b/openprescribing/data/ingestors/prescribing.py
@@ -100,13 +100,6 @@ def ingest(force=False):
     # Ingest all the data by querying the source views and writing the results to tables
     ingest_sources(conn)
 
-    max_date, twelve_months_start_date = conn.execute(
-        "SELECT MAX(date), CAST(MAX(date) - INTERVAL 11 MONTH AS DATE) FROM date"
-    ).fetchone()
-    build_subset_tables(conn, "1m", max_date, max_date)
-    build_subset_tables(conn, "12m", twelve_months_start_date, max_date)
-    build_subset_tables(conn, "2025", "2025-01-01", "2025-12-01")
-
     conn.close()
     tmp_file.replace(target_file)
 
@@ -212,7 +205,20 @@ def ingest_sources(conn):
     # decide whether to ingest less, or to change the type here and pay the extra cost
     # in storage and performance. Nothing else in the system depends on these exact
     # types though, so it shouldn't be a disruptive change.
-    conn.sql(f"CREATE TABLE prescribing_norm ({sql_for_prescribing_norm_schema()})")
+    conn.sql(
+        """
+        CREATE TABLE prescribing_norm (
+            presentation_id INT4,
+            date_id UTINYINT,
+            practice_id USMALLINT,
+            quantity_value FLOAT4,
+            items USMALLINT,
+            quantity FLOAT4,
+            net_cost UINTEGER,
+            actual_cost UINTEGER
+        )
+        """
+    )
 
     # The order in which we insert the normalised prescribing data is important because
     # it allows DuckDB to produce more useful zonemaps, which improves query performance.
@@ -252,15 +258,10 @@ def ingest_sources(conn):
     # To make ad-hoc queries of the data easier we create denormalised views which
     # include the practice codes, dates etc rather than just foreign keys
     log.info("Building `prescribing` view")
-    conn.sql(
-        "CREATE VIEW prescribing AS "
-        + sql_for_prescribing_denormalised("prescribing_norm")
-    )
+    conn.sql("CREATE VIEW prescribing AS " + sql_for_prescribing_denormalised())
 
     log.info("Building `list_size` view")
-    conn.sql(
-        "CREATE VIEW list_size AS " + sql_for_list_size_denormalised("list_size_norm")
-    )
+    conn.sql("CREATE VIEW list_size AS " + sql_for_list_size_denormalised())
 
     # To support BNF codes changing we need to update the presentation table with the
     # BNF code that a presentation would have, if it had been prescribed today.  We
@@ -277,80 +278,6 @@ def ingest_sources(conn):
     LEFT JOIN bnf_code_changes_source
         ON presentation.bnf_code = bnf_code_changes_source.old_code
     """)
-
-
-def build_subset_tables(conn, suffix, start_date, end_date):
-    # Build a date-restricted subset of the prescribing and list_size data as
-    # standalone tables named `prescribing_{suffix}` etc, covering dates in
-    # [start_date, end_date] inclusive.
-
-    date_ids = [
-        row[0]
-        for row in conn.execute(
-            "SELECT id FROM date WHERE date BETWEEN ? AND ? ORDER BY id",
-            [start_date, end_date],
-        ).fetchall()
-    ]
-    if not date_ids:
-        log.info(f"No data in [{start_date}, {end_date}]; skipping `{suffix}` tables")
-        return
-
-    date_id_list = ",".join(str(d) for d in date_ids)
-    prescribing_norm_name = f"prescribing_norm_{suffix}"
-    prescribing_name = f"prescribing_{suffix}"
-    list_size_norm_name = f"list_size_norm_{suffix}"
-    list_size_name = f"list_size_{suffix}"
-
-    log.info(
-        f"Building `{suffix}` subset tables for {len(date_ids)} date_ids "
-        f"({start_date} -> {end_date})"
-    )
-
-    log.info(f"Building `{list_size_norm_name}`")
-    conn.sql(
-        f"CREATE TABLE {list_size_norm_name} AS"
-        f" SELECT * FROM list_size_norm WHERE date_id IN ({date_id_list})"
-    )
-
-    conn.sql(
-        f"CREATE TABLE {prescribing_norm_name} ({sql_for_prescribing_norm_schema()})"
-    )
-
-    for bnf_start, bnf_end in get_bnf_code_ranges(
-        conn, batch_size=BNF_RANGE_BATCH_SIZE
-    ):
-        conn.execute(
-            f"INSERT INTO {prescribing_norm_name}"
-            " SELECT prescribing_norm.* FROM prescribing_norm"
-            " JOIN presentation ON prescribing_norm.presentation_id = presentation.id"
-            " WHERE presentation.bnf_code >= ? AND presentation.bnf_code < ?"
-            f"  AND prescribing_norm.date_id IN ({date_id_list})"
-            " ORDER BY"
-            " prescribing_norm.presentation_id,"
-            " prescribing_norm.date_id,"
-            " prescribing_norm.practice_id",
-            [bnf_start, bnf_end],
-        )
-
-    log.info(f"Building `{prescribing_name}` view")
-    conn.sql(
-        f"CREATE VIEW {prescribing_name} AS "
-        + sql_for_prescribing_denormalised(prescribing_norm_name)
-    )
-
-    log.info(f"Building `{list_size_name}` view")
-    conn.sql(
-        f"CREATE VIEW {list_size_name} AS "
-        + sql_for_list_size_denormalised(list_size_norm_name)
-    )
-
-    log.info(
-        f"Ingested {count_table(conn, prescribing_norm_name):,} "
-        f"`{suffix}` prescribing rows"
-    )
-    log.info(
-        f"Ingested {count_table(conn, list_size_norm_name):,} `{suffix}` list size rows"
-    )
 
 
 def sql_for_date_table():
@@ -444,19 +371,6 @@ def sql_for_presentation_table():
     """
 
 
-def sql_for_prescribing_norm_schema():
-    return """
-        presentation_id INT4,
-        date_id UTINYINT,
-        practice_id USMALLINT,
-        quantity_value FLOAT4,
-        items USMALLINT,
-        quantity FLOAT4,
-        net_cost UINTEGER,
-        actual_cost UINTEGER
-    """
-
-
 def sql_for_prescribing_normalised():
     return """\
     SELECT
@@ -482,8 +396,8 @@ def sql_for_prescribing_normalised():
     """
 
 
-def sql_for_prescribing_denormalised(prescribing_norm_name):
-    return f"""\
+def sql_for_prescribing_denormalised():
+    return """\
     SELECT
         rx.presentation_id AS presentation_id,
         presentation.bnf_code AS bnf_code,
@@ -498,7 +412,7 @@ def sql_for_prescribing_denormalised(prescribing_norm_name):
         rx.net_cost AS net_cost,
         rx.actual_cost AS actual_cost
     FROM
-        {prescribing_norm_name} AS rx
+        prescribing_norm AS rx
     JOIN
         presentation
     ON
@@ -531,8 +445,8 @@ def sql_for_list_size_normalised():
     """
 
 
-def sql_for_list_size_denormalised(list_size_norm_name):
-    return f"""\
+def sql_for_list_size_denormalised():
+    return """\
     SELECT
         lst.date_id AS date_id,
         date.date AS date,
@@ -540,7 +454,7 @@ def sql_for_list_size_denormalised(list_size_norm_name):
         practice.code AS practice_code,
         lst.total AS total
     FROM
-        {list_size_norm_name} AS lst
+        list_size_norm AS lst
     JOIN
         date
     ON

--- a/tests/data/ingestors/test_prescribing.py
+++ b/tests/data/ingestors/test_prescribing.py
@@ -1,5 +1,4 @@
 import csv
-import datetime
 
 import duckdb
 
@@ -35,18 +34,6 @@ def test_prescribing_ingest(tmp_path, settings):
         "list_size_norm",
         "list_size",
         "ingested_file",
-        "prescribing_norm_2025",
-        "prescribing_2025",
-        "list_size_norm_2025",
-        "list_size_2025",
-        "prescribing_norm_12m",
-        "prescribing_12m",
-        "list_size_norm_12m",
-        "list_size_12m",
-        "prescribing_norm_1m",
-        "prescribing_1m",
-        "list_size_norm_1m",
-        "list_size_1m",
     }
     for name, table in tables.items():
         assert len(table) > 0, f"table '{name}' is empty"
@@ -159,23 +146,6 @@ def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings):
     ]
 
 
-def test_build_subset_tables_skips_empty_window():
-    conn = duckdb.connect()
-    conn.sql("CREATE TABLE date (id UTINYINT, date DATE)")
-    conn.execute("INSERT INTO date VALUES (0, ?)", [datetime.date(2020, 1, 1)])
-
-    prescribing.build_subset_tables(
-        conn, "empty", datetime.date(2030, 1, 1), datetime.date(2031, 1, 1)
-    )
-
-    cursor = conn.execute(
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
-    )
-    table_names = {r[0] for r in cursor.fetchall()}
-    assert "prescribing_norm_empty" not in table_names
-    assert "list_size_norm_empty" not in table_names
-
-
 def generate_prescribing_data():
     # TODO: Randomly generate a whole load of prescribing data
     return {
@@ -203,15 +173,6 @@ def generate_prescribing_data():
             },
         ],
         ("list_size", "2020-01-01", "v2"): [
-            {
-                "ORG_CODE": "ABC123",
-                "NUMBER_OF_PATIENTS": "12345",
-                "ORG_TYPE": "GP",
-                "SEX": "ALL",
-                "AGE_GROUP_5": "ALL",
-            },
-        ],
-        ("list_size", "2025-01-01", "v2"): [
             {
                 "ORG_CODE": "ABC123",
                 "NUMBER_OF_PATIENTS": "12345",


### PR DESCRIPTION
The new subset tables are not necessary, as we have found an alternative approach (basically: materialising views) to speeding up queries in Streamlit.

0a30369 was added in #340.