### PR TITLE
Clean up temporary database after ingest failure

### DIFF
--- a/openprescribing/data/ingestors/prescribing.py
+++ b/openprescribing/data/ingestors/prescribing.py
@@ -58,12 +58,28 @@ def ingest(force=False):
     for filename in all_files:
         log.info(f"Preparing to ingest file: {filename.name}")
 
+    # We build the database in a new file, and atomically replace the old file with the
+    # new one.
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_file = get_temp_filename_for(target_file)
+
+    try:
+        build_database(
+            conn, tmp_file, target_file, all_files, prescribing_files, list_size_files
+        )
+        conn.close()
+        tmp_file.replace(target_file)
+    finally:
+        tmp_file.unlink(missing_ok=True)
+
+
+def build_database(
+    conn, tmp_file, target_file, all_files, prescribing_files, list_size_files
+):
     # Attach the file we're in the process of building under the schema name "new". The
     # STORAGE_VERSION setting allows us to opt-in to newer DuckDB file format features
     # which can't be read by older clients. If a newer release offers a feature we want
     # we can bump the version here.
-    target_file.parent.mkdir(parents=True, exist_ok=True)
-    tmp_file = get_temp_filename_for(target_file)
     conn.sql(f"ATTACH {escape(tmp_file)} AS new (STORAGE_VERSION 'v1.2.0')")
 
     # Record the names of the files we're ingesting
@@ -99,9 +115,6 @@ def ingest(force=False):
 
     # Ingest all the data by querying the source views and writing the results to tables
     ingest_sources(conn)
-
-    conn.close()
-    tmp_file.replace(target_file)
 
 
 def sql_for_prescribing_source_view(prescribing_files_by_date):

--- a/openprescribing/data/ingestors/prescribing.py
+++ b/openprescribing/data/ingestors/prescribing.py
@@ -64,18 +64,14 @@ def ingest(force=False):
     tmp_file = get_temp_filename_for(target_file)
 
     try:
-        build_database(
-            conn, tmp_file, target_file, all_files, prescribing_files, list_size_files
-        )
+        build_database(conn, tmp_file, all_files, prescribing_files, list_size_files)
         conn.close()
         tmp_file.replace(target_file)
     finally:
         tmp_file.unlink(missing_ok=True)
 
 
-def build_database(
-    conn, tmp_file, target_file, all_files, prescribing_files, list_size_files
-):
+def build_database(conn, tmp_file, all_files, prescribing_files, list_size_files):
     # Attach the file we're in the process of building under the schema name "new". The
     # STORAGE_VERSION setting allows us to opt-in to newer DuckDB file format features
     # which can't be read by older clients. If a newer release offers a feature we want

--- a/tests/data/ingestors/test_prescribing.py
+++ b/tests/data/ingestors/test_prescribing.py
@@ -1,6 +1,7 @@
 import csv
 
 import duckdb
+import pytest
 
 from openprescribing.data.ingestors import prescribing
 from tests.utils.parquet_utils import parquet_from_dicts
@@ -144,6 +145,25 @@ def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings):
         "NEW12345",
         "01234ABC",
     ]
+
+
+def test_prescribing_ingest_cleans_up_tmp_file_on_failure(
+    tmp_path, settings, monkeypatch
+):
+    settings.DOWNLOAD_DIR = tmp_path / "downloads"
+    settings.PRESCRIBING_DATABASE = tmp_path / "data" / "prescribing.duckdb"
+
+    write_as_parquet_files(generate_prescribing_data(), settings.DOWNLOAD_DIR)
+
+    def oom(conn):
+        raise RuntimeError("oom")
+
+    monkeypatch.setattr(prescribing, "ingest_sources", oom)
+
+    with pytest.raises(RuntimeError, match="oom"):
+        prescribing.ingest()
+
+    assert list(settings.PRESCRIBING_DATABASE.parent.glob(".*.tmp")) == []
 
 
 def generate_prescribing_data():


### PR DESCRIPTION
If the prescribing ingest fails partway through, then we can end up with undeleted .tmp files and run out of disk space.