### PR TITLE
Limit duckdb memory usage to 8GB in prescribing ingest

### DIFF
--- a/openprescribing/data/ingestors/prescribing.py
+++ b/openprescribing/data/ingestors/prescribing.py
@@ -42,6 +42,9 @@ def ingest(force=False):
 
     conn = duckdb.connect()
 
+    # 8GB is a finger in the air guess, for testing
+    conn.sql("SET memory_limit = '8GB';")
+
     if not force and target_file.exists():
         conn.sql(f"ATTACH {escape(target_file)} AS old (READONLY)")
         ingested_files = {


### PR DESCRIPTION
* nb. I'm not sure how far this will persist
* I'd like to try out an ingest with this setting to see the effect on real world memory usage