### PR TITLE
Handle VMP code changes in prescribing ingestor

### DIFF
--- a/openprescribing/data/ingestors/prescribing.py
+++ b/openprescribing/data/ingestors/prescribing.py
@@ -4,6 +4,7 @@ import os
 import duckdb
 from django.conf import settings
 
+from openprescribing.data.models.dmd import VMP
 from openprescribing.data.utils.duckdb_utils import escape
 from openprescribing.data.utils.filename_utils import (
     get_latest_files_by_date,
@@ -108,6 +109,7 @@ def build_database(conn, tmp_file, all_files, prescribing_files, list_size_files
             settings.BNF_CODE_CHANGES_DIR / "bnf_code_mapping.csv"
         )
     )
+    create_vmp_code_changes_source(conn)
 
     # Set the new database we're building as the default schema
     conn.sql("USE new")
@@ -275,9 +277,10 @@ def ingest_sources(conn):
     log.info("Building `list_size` view")
     conn.sql("CREATE VIEW list_size AS " + sql_for_list_size_denormalised())
 
-    # To support BNF codes changing we need to update the presentation table with the
-    # BNF code that a presentation would have, if it had been prescribed today.  We
-    # keep the original in the original_bnf_code column for debugging purposes.
+    # To support BNF codes and VMP codes changing we need to update the presentation
+    # table with the codes that a presentation would have, if it had been prescribed
+    # today.  We keep the originals in the original_bnf_code and original_snomed_code
+    # columns for debugging purposes.
     log.info("Updating `presentation` table")
     conn.sql("""
     CREATE OR REPLACE TABLE presentation AS
@@ -285,10 +288,13 @@ def ingest_sources(conn):
         presentation.id,
         COALESCE(bnf_code_changes_source.new_code, presentation.bnf_code) AS bnf_code,
         presentation.bnf_code AS original_bnf_code,
-        presentation.snomed_code
+        COALESCE(vmp_code_changes_source.new_vpid, presentation.snomed_code) AS snomed_code,
+        presentation.snomed_code AS original_snomed_code
     FROM presentation
     LEFT JOIN bnf_code_changes_source
         ON presentation.bnf_code = bnf_code_changes_source.old_code
+    LEFT JOIN vmp_code_changes_source
+        ON presentation.snomed_code = vmp_code_changes_source.old_vpid
     """)
 
 
@@ -476,6 +482,47 @@ def sql_for_list_size_denormalised():
     ON
         lst.practice_id = practice.id
     """
+
+
+def create_vmp_code_changes_source(conn):
+    # VMP codes occasionally change.  Each VMP record carries its immediately previous
+    # code in `vpidprev`, so a chain of changes A -> B -> C is recorded across multiple
+    # rows (B has vpidprev=A; C has vpidprev=B).  We resolve chains so that the final
+    # mapping points each old code directly at the current code (A -> C, B -> C).
+    pairs = resolve_vmp_code_changes(get_vmp_code_change_pairs())
+    conn.sql(
+        "CREATE TEMPORARY TABLE vmp_code_changes_source (old_vpid BIGINT, new_vpid BIGINT)"
+    )
+    if pairs:
+        conn.executemany(
+            "INSERT INTO vmp_code_changes_source VALUES (?, ?)",
+            pairs,
+        )
+
+
+def get_vmp_code_change_pairs():
+    # Fetch all (current_vpid, previous_vpid) pairs from the dm+d data.
+    return VMP.objects.exclude(vpidprev__isnull=True).values_list("vpid", "vpidprev")
+
+
+def resolve_vmp_code_changes(raw_pairs):
+    # Given an iterable of (current_vpid, previous_vpid) pairs, resolve any chains so
+    # that each old code maps directly to the current code.  Returns a list of
+    # (old_vpid, new_vpid) tuples.
+    prev_to_current = {prev: current for current, prev in raw_pairs}
+    old_to_new = {}
+    for start in prev_to_current:
+        seen = {start}
+        current = start
+        while current in prev_to_current:
+            current = prev_to_current[current]
+            if current in seen:
+                raise ValueError(
+                    f"Cycle detected in VMP vpidprev chain involving {current}"
+                )
+            seen.add(current)
+        old_to_new[start] = current
+    return sorted(old_to_new.items())
 
 
 def sql_for_bnf_code_changes_view(csv_path):

--- a/tests/data/ingestors/test_prescribing.py
+++ b/tests/data/ingestors/test_prescribing.py
@@ -7,7 +7,7 @@ from openprescribing.data.ingestors import prescribing
 from tests.utils.parquet_utils import parquet_from_dicts
 
 
-def test_prescribing_ingest(tmp_path, settings):
+def test_prescribing_ingest(tmp_path, settings, data_db):
     settings.DOWNLOAD_DIR = tmp_path / "downloads"
     settings.PRESCRIBING_DATABASE = tmp_path / "data" / "prescribing.duckdb"
 
@@ -46,7 +46,7 @@ def test_prescribing_ingest(tmp_path, settings):
     assert settings.PRESCRIBING_DATABASE.stat().st_mtime == last_modified
 
 
-def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings):
+def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings, data_db):
     settings.DOWNLOAD_DIR = tmp_path / "downloads"
     settings.PRESCRIBING_DATABASE = tmp_path / "data" / "prescribing.duckdb"
     settings.BNF_CODE_CHANGES_DIR = tmp_path
@@ -122,18 +122,21 @@ def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings):
             "bnf_code": "01234ABC",
             "original_bnf_code": "01234ABC",
             "snomed_code": 87654321,
+            "original_snomed_code": 87654321,
         },
         {
             "id": 2,
             "bnf_code": "NEW12345",
             "original_bnf_code": "NEW12345",
             "snomed_code": 12345678,
+            "original_snomed_code": 12345678,
         },
         {
             "id": 3,
             "bnf_code": "NEW12345",
             "original_bnf_code": "OLD12345",
             "snomed_code": 12345678,
+            "original_snomed_code": 12345678,
         },
     ]
 
@@ -147,8 +150,118 @@ def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings):
     ]
 
 
+def test_prescribing_ingest_applies_vmp_code_changes(
+    tmp_path, settings, data_db, monkeypatch
+):
+    settings.DOWNLOAD_DIR = tmp_path / "downloads"
+    settings.PRESCRIBING_DATABASE = tmp_path / "data" / "prescribing.duckdb"
+
+    test_data = {
+        ("prescribing", "2023-01-01", "v3"): [
+            {
+                "BNF_CODE": "01234ABC",
+                "SNOMED_CODE": "1000",
+                "PRACTICE_CODE": "ABC123",
+                "QUANTITY": "10.0",
+                "ITEMS": "100",
+                "TOTAL_QUANTITY": "150.0",
+                "NIC": "12.34",
+                "ACTUAL_COST": "15.34",
+            },
+        ],
+        ("prescribing", "2024-01-01", "v3"): [
+            {
+                "BNF_CODE": "01234ABC",
+                "SNOMED_CODE": "2000",
+                "PRACTICE_CODE": "ABC123",
+                "QUANTITY": "12.0",
+                "ITEMS": "110",
+                "TOTAL_QUANTITY": "160.0",
+                "NIC": "14.34",
+                "ACTUAL_COST": "17.34",
+            },
+        ],
+        ("prescribing", "2025-01-01", "v3"): [
+            {
+                "BNF_CODE": "01234ABC",
+                "SNOMED_CODE": "3000",
+                "PRACTICE_CODE": "ABC123",
+                "QUANTITY": "14.0",
+                "ITEMS": "120",
+                "TOTAL_QUANTITY": "170.0",
+                "NIC": "16.34",
+                "ACTUAL_COST": "19.34",
+            },
+        ],
+        ("list_size", "2023-01-01", "v2"): [
+            {
+                "ORG_CODE": "ABC123",
+                "NUMBER_OF_PATIENTS": "12345",
+                "ORG_TYPE": "GP",
+                "SEX": "ALL",
+                "AGE_GROUP_5": "ALL",
+            },
+        ],
+    }
+    write_as_parquet_files(test_data, settings.DOWNLOAD_DIR)
+
+    # Simulate a chain of VMP code changes: 1000 -> 2000 -> 3000. Both old codes should
+    # resolve to the current code (3000).
+    monkeypatch.setattr(
+        prescribing,
+        "get_vmp_code_change_pairs",
+        lambda: [(2000, 1000), (3000, 2000)],
+    )
+
+    prescribing.ingest()
+
+    tables = get_all_tables(settings.PRESCRIBING_DATABASE)
+
+    presentation_rows = sorted(
+        tables["presentation"], key=lambda row: row["original_snomed_code"]
+    )
+    assert presentation_rows == [
+        {
+            "id": 1,
+            "bnf_code": "01234ABC",
+            "original_bnf_code": "01234ABC",
+            "snomed_code": 3000,
+            "original_snomed_code": 1000,
+        },
+        {
+            "id": 2,
+            "bnf_code": "01234ABC",
+            "original_bnf_code": "01234ABC",
+            "snomed_code": 3000,
+            "original_snomed_code": 2000,
+        },
+        {
+            "id": 3,
+            "bnf_code": "01234ABC",
+            "original_bnf_code": "01234ABC",
+            "snomed_code": 3000,
+            "original_snomed_code": 3000,
+        },
+    ]
+
+    prescribing_rows = sorted(tables["prescribing"], key=lambda row: row["date"])
+    assert [r["snomed_code"] for r in prescribing_rows] == [3000, 3000, 3000]
+
+
+def test_resolve_vmp_code_changes():
+    assert prescribing.resolve_vmp_code_changes([(20, 10), (30, 20)]) == [
+        (10, 30),
+        (20, 30),
+    ]
+
+
+def test_resolve_vmp_code_changes_detects_cycle():
+    with pytest.raises(ValueError, match="Cycle"):
+        prescribing.resolve_vmp_code_changes([(10, 20), (20, 10)])
+
+
 def test_prescribing_ingest_cleans_up_tmp_file_on_failure(
-    tmp_path, settings, monkeypatch
+    tmp_path, settings, data_db, monkeypatch
 ):
     settings.DOWNLOAD_DIR = tmp_path / "downloads"
     settings.PRESCRIBING_DATABASE = tmp_path / "data" / "prescribing.duckdb"

--- a/tests/utils/rxdb_utils.py
+++ b/tests/utils/rxdb_utils.py
@@ -57,6 +57,13 @@ BNF_CODE_CHANGES_SOURCE_SCHEMA = pyarrow.schema(
     ]
 )
 
+VMP_CODE_CHANGES_SOURCE_SCHEMA = pyarrow.schema(
+    [
+        ("old_vpid", pyarrow.int64()),
+        ("new_vpid", pyarrow.int64()),
+    ]
+)
+
 LIST_SIZE_SOURCE_DEFAULTS = {
     "date": datetime.date(2000, 1, 1),
     "practice_code": "",
@@ -129,14 +136,19 @@ def rxdb_ingest(conn, prescribing_data=(), list_size_data=()):
     bnf_code_changes_source = pyarrow.Table.from_pylist(
         [], schema=BNF_CODE_CHANGES_SOURCE_SCHEMA
     )
+    vmp_code_changes_source = pyarrow.Table.from_pylist(
+        [], schema=VMP_CODE_CHANGES_SOURCE_SCHEMA
+    )
     # Register the PyArrow Tables so they can be queried like any other table in DuckDB
     conn.register("prescribing_source", prescribing_source)
     conn.register("list_size_source", list_size_source)
     conn.register("bnf_code_changes_source", bnf_code_changes_source)
+    conn.register("vmp_code_changes_source", vmp_code_changes_source)
     ingest_sources(conn)
     conn.unregister("prescribing_source")
     conn.unregister("list_size_source")
     conn.unregister("bnf_code_changes_source")
+    conn.unregister("vmp_code_changes_source")
 
 
 def prepare_data(data, defaults):


### PR DESCRIPTION
VMP codes can change.  That is: the same medication might be recorded with different codes at different points in time.

This commit updates the prescribing ingestor to account for this.  The presentations table grows an extra column, snomed_code_original, that records the code that the presentation was originally given.  The snomed_code column is repurposed to record the code that the presentation would have been given had it been prescribed today.

Note that AMP codes do not change.

See also #145 for the introduction of corresponding functionality for BNF codes.