### PR TITLE
Allow duckdb to write tmp files in production

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,6 +1,7 @@
 DJANGO_CSRF_TRUSTED_ORIGINS="http://127.0.0.1"
 DJANGO_DEBUG="True"
 DJANGO_SECRET_KEY="django-insecure-_)wr$24j5r(iqyloz8i1@uo$h+bqxw_2(@6#r!f@8dsu^9*+py"
+DUCKDB_TMP_DIRECTORY="work_dir/tmp"
 OPENPRESCRIBING_DATA_DIR="work_dir/data"
 OPENPRESCRIBING_DOWNLOAD_DIR="work_dir/downloads"
 OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io

--- a/openprescribing/config/settings.py
+++ b/openprescribing/config/settings.py
@@ -61,6 +61,7 @@ else:
 # BASE_DIR: if they are absolute paths then they can point anywhere.
 DOWNLOAD_DIR = BASE_DIR / get_env_var("OPENPRESCRIBING_DOWNLOAD_DIR")
 DATA_DIR = BASE_DIR / get_env_var("OPENPRESCRIBING_DATA_DIR")
+DUCKDB_TMP_DIRECTORY = BASE_DIR / get_env_var("DUCKDB_TMP_DIRECTORY")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/

--- a/openprescribing/data/ingestors/prescribing.py
+++ b/openprescribing/data/ingestors/prescribing.py
@@ -45,6 +45,13 @@ def ingest(force=False):
     # 8GB is a finger in the air guess, for testing
     conn.sql("SET memory_limit = '8GB';")
 
+    # In production the container runs as user 10001, so we need
+    # to direct this to a directory where we have write access
+    conn.sql(f"SET temp_directory = '{settings.DUCKDB_TMP_DIRECTORY}';")
+    # At the time of writing, total imported db size is typically 22GB
+    # and we have around 60GB free disk space.
+    conn.sql("SET max_temp_directory_size = '40GB';")
+
     if not force and target_file.exists():
         conn.sql(f"ATTACH {escape(target_file)} AS old (READONLY)")
         ingested_files = {


### PR DESCRIPTION
* due to the memory limit, duckdb will now need to use tmp files when it runs out of memory
* it doesn't have write access to `BASE_DIR` (`/app`), so point it towards somewhere that it does
* configured in production with `dokku config:set openprescribing DUCKDB_TMP_DIRECTORY="/storage/duckdb_tmp"`