### PR TITLE
Add NSAID BNF codes; exclude ibuprofen/naproxen

### DIFF
--- a/measure_definitions/ktt13_nsaids_ibuprofen.yaml
+++ b/measure_definitions/ktt13_nsaids_ibuprofen.yaml
@@ -21,4 +21,11 @@ queries:
   - numerator:
       bnf_codes:
         included:
-          - ""
+          - "100101" # Non-Steroidal Anti-Inflammatory Drugs
+        excluded:
+          - "1001010J0" # Ibuprofen
+          - "1001010P0" # Naproxen
+    denominator:
+      bnf_codes:
+        included:
+          - "100101" # Non-Steroidal Anti-Inflammatory Drugs       


### PR DESCRIPTION
Replace empty BNF include with code 100101 (Non-Steroidal Anti-Inflammatory Drugs), add exclusions for specific product codes 1001010J0 (Ibuprofen) and 1001010P0 (Naproxen), and include 100101 in the denominator.