### PR TITLE
Add BNF codes for trimethoprim and nitrofurantoin

### DIFF
--- a/measure_definitions/trimethoprim.yaml
+++ b/measure_definitions/trimethoprim.yaml
@@ -18,4 +18,9 @@ queries:
   - numerator:
       bnf_codes:
         included:
-          - ""
+          - "0501080W0" # Trimethoprim
+    denominator:
+      bnf_codes:
+        included:
+          - "0501080W0" # Trimethoprim
+          - "0501130R0" # Nitrofurantoin


### PR DESCRIPTION
Populate measure definitions for the numerator and the denominator.