### PR TITLE
Fix "Edit analysis" button

### DIFF
--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -45,10 +45,13 @@ def _build_analysis_context(analysis):
                 analysis.ntr_query, None
             )
 
-        url_parameters = urlencode({"analysis": json.dumps(analysis.to_dict())})
-        build_analysis_url = f"{reverse('build-analysis')}?{url_parameters}"
-        deciles_api_url = f"{reverse('api_prescribing_deciles')}?{url_parameters}"
-        all_orgs_api_url = f"{reverse('api_prescribing_all_orgs')}?{url_parameters}"
+        url_parameters_params = urlencode(analysis.to_params(), safe=",")
+        url_parameters_json = urlencode({"analysis": json.dumps(analysis.to_dict())})
+        build_analysis_url = f"{reverse('build-analysis')}?{url_parameters_params}"
+        deciles_api_url = f"{reverse('api_prescribing_deciles')}?{url_parameters_json}"
+        all_orgs_api_url = (
+            f"{reverse('api_prescribing_all_orgs')}?{url_parameters_json}"
+        )
 
     orgs = make_orgs()
 


### PR DESCRIPTION
* the javascript for the build page only supports "param" style url parameters
* this was unintentionally introduced in #324 (the PR description does not match the code)