### PR TITLE
Fix get-prod-data just recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -214,7 +214,7 @@ get-prod-data *args:
     }
 
     local_work_dir=$(get_setting DATA_DIR)
-    remote_work_dir=$(ssh $HOST "dokku storage:list openprescribing" | grep -v downloads | cut -d: -f1)
+    remote_work_dir=$(ssh $HOST "dokku storage:list openprescribing" | grep "/storage$" | cut -d: -f1)
 
     if [ "$#" -gt 0 ]; then
         databases=("$@")


### PR DESCRIPTION
We now have three dokku storages attached, so need to be more precise about which one contains the database files we are looking for.