### PR TITLE
Add BNF codes for vit B numerator/denominator

### DIFF
--- a/measure_definitions/vitb.yaml
+++ b/measure_definitions/vitb.yaml
@@ -19,4 +19,12 @@ queries:
   - numerator:
       bnf_codes:
         included:
-          - ""
+          - "0906027G0_AA" # Vit B Co_Tab
+          - "0906027G0_AB" # Vit B Co_Str_Tab
+    denominator:
+      bnf_codes:
+        included:
+          - "0906027G0_AA" # Vit B Co_Tab
+          - "0906027G0_AB" # Vit B Co_Str_Tab
+          - "0906026M0_AF" # Thiamine HCL_Tab 50mg
+          - "0906026M0_AG" # Thiamine HCL_Tab 100mg


### PR DESCRIPTION
Replace placeholder empty BNF entry with explicit codes for the vitamin B measure.