### PR TITLE
Add BNF code for Vit B compound

### DIFF
--- a/measure_definitions/vitbper1000.yaml
+++ b/measure_definitions/vitbper1000.yaml
@@ -19,4 +19,4 @@ queries:
   - numerator:
       bnf_codes:
         included:
-          - ""
+          - "0906027G0" # Vit B Compound


### PR DESCRIPTION
Replace an empty BNF code with '0906027G0' in measure_definitions