### PR TITLE
Batch the order & copy from prescribing_norm_tmp

### DIFF
--- a/openprescribing/data/ingestors/prescribing.py
+++ b/openprescribing/data/ingestors/prescribing.py
@@ -281,10 +281,30 @@ def ingest_sources(conn):
             params=[bnf_start, bnf_end],
         )
 
-    conn.sql(
-        "INSERT INTO prescribing_norm SELECT * FROM prescribing_norm_tmp "
-        " ORDER BY presentation_id, date_id, practice_id"
-    )
+    for bnf_start, bnf_end in get_bnf_code_ranges(
+        conn, batch_size=BNF_RANGE_BATCH_SIZE
+    ):
+        log.info(f"Building `prescribing_norm` table: {bnf_start} -> {bnf_end}")
+        conn.sql(
+            # Copy all fields /except/ bnf_code from prescribing_norm_tmp
+            """\
+            INSERT INTO prescribing_norm
+            SELECT
+                presentation_id,
+                date_id,
+                practice_id,
+                quantity_value,
+                items,
+                quantity,
+                net_cost,
+                actual_cost
+            FROM prescribing_norm_tmp
+            WHERE prescribing_norm_tmp.bnf_code >= ? AND prescribing_norm_tmp.bnf_code < ?
+            ORDER BY presentation_id, date_id, practice_id
+            """,
+            params=[bnf_start, bnf_end],
+        )
+
     conn.sql("DROP TABLE prescribing_norm_tmp ")
     log.info(f"Ingested {count_table(conn, 'prescribing_norm'):,} prescribing rows")
 
@@ -412,6 +432,7 @@ def sql_for_prescribing_normalised():
     return """\
     SELECT
         presentation.id AS presentation_id,
+        presentation.bnf_code AS bnf_code,
         date.id AS date_id,
         practice.id AS practice_id,
         prescribing_source.quantity_value,


### PR DESCRIPTION
* I tested this locally with a constrained environment:
  * 500MB RAM & 50GB tmp disk available to duckdb
  * just the 2026 data
* For the current `main` ingest:
  * tmp disk usage reached 2.5GB whilst creating the tmp table
  * tmp disk usage reached 6.5GB whilst inserting from the tmp table to the actual table
* For this branch ingest:
  * tmp disk usage reached 3.3GB whilst creating the tmp table
  * tmp disk upage remained at 3.3GB whilst inserting from the tmp table to the actual table
* It was a surprise that the tmp table appeared to require more tmp disk space to do the same thing, however the overall usage was significantly lower
* Wall clock time on my developer laptop was similar for this PR compared to main, however on the production server I would suspect that it would be quicker
  * this is because I think the tmp disk is on a slower hard-drive type device, and attached over a network, which I think it would make it relatively a lot more expensive than the storage on my developer laptop
  * the only real way to compare this is to experiment with it on production or a production-class machine