### PR TITLE
Fix BNFQuery.to_dict serialisation

### DIFF
--- a/openprescribing/data/bnf_query.py
+++ b/openprescribing/data/bnf_query.py
@@ -168,15 +168,30 @@ class BNFQuery:
             query_dict.get("forms", []),
             query_dict.get("routes", []),
         )
+        form_route_ids_excluded = _get_form_route_ids_for_forms_and_routes(
+            query_dict.get("form_routes_excluded", []),
+            query_dict.get("forms_excluded", []),
+            query_dict.get("routes_excluded", []),
+        )
 
         ingredient_ids = tuple(str(i) for i in query_dict.get("ingredient_ids", []))
+        ingredient_ids_excluded = tuple(
+            str(i) for i in query_dict.get("ingredient_ids_excluded", [])
+        )
+
+        vtm_ids = tuple(str(i) for i in query_dict.get("vtm_ids", []))
+        vtm_ids_excluded = tuple(str(i) for i in query_dict.get("vtm_ids_excluded", []))
 
         return cls(
             tuple(bnf_codes_dict["included"]),
             tuple(bnf_codes_dict.get("excluded", [])),
             ProductType(product_type),
             form_route_ids=form_route_ids,
+            form_route_ids_excluded=form_route_ids_excluded,
             ingredient_ids=ingredient_ids,
+            ingredient_ids_excluded=ingredient_ids_excluded,
+            vtm_ids=vtm_ids,
+            vtm_ids_excluded=vtm_ids_excluded,
         )
 
     def to_dict(self):
@@ -194,8 +209,23 @@ class BNFQuery:
                     cd__in=self.form_route_ids
                 )
             ]
+        if self.form_route_ids_excluded:
+            bnf_query_dict["form_routes_excluded"] = [
+                str(form_route.descr)
+                for form_route in OntFormRoute.objects.filter(
+                    cd__in=self.form_route_ids_excluded
+                )
+            ]
         if self.ingredient_ids:
             bnf_query_dict["ingredient_ids"] = list(self.ingredient_ids)
+        if self.ingredient_ids_excluded:
+            bnf_query_dict["ingredient_ids_excluded"] = list(
+                self.ingredient_ids_excluded
+            )
+        if self.vtm_ids:
+            bnf_query_dict["vtm_ids"] = list(self.vtm_ids)
+        if self.vtm_ids_excluded:
+            bnf_query_dict["vtm_ids_excluded"] = list(self.vtm_ids_excluded)
 
         return bnf_query_dict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ exclude-newer-package = {}
 [dependency-groups]
 dev = [
     "coverage>=7.10.6",
+    "hypothesis>=6.152.9",
     "playwright>=1.56.0",
     "pre-commit>=4.3.0",
     "pytest>=8.4.1",

--- a/tests/data/test_bnf_query.py
+++ b/tests/data/test_bnf_query.py
@@ -612,26 +612,151 @@ def test_to_params_with_ingredient_ids():
     }
 
 
-def test_from_dict():
-    test_dict = {
+def test_to_dict_bnf_codes_included():
+    query = BNFQuery(bnf_codes=["1001030U0"])
+    assert query.to_dict() == {"bnf_codes": {"included": ["1001030U0"]}}
+
+
+def test_to_dict_bnf_codes_excluded():
+    query = BNFQuery(bnf_codes=["1001030U0"], bnf_codes_excluded=["1001030U0AAABAB"])
+    assert query.to_dict() == {
         "bnf_codes": {
-            "included": ["01"],
+            "included": ["1001030U0"],
+            "excluded": ["1001030U0AAABAB"],
         }
     }
-    query = BNFQuery.from_dict(test_dict)
-    assert query.to_dict() == test_dict
 
 
-def test_from_dict_generic():
-    test_dict = {
-        "bnf_codes": {
-            "included": ["01"],
-            "excluded": ["0101"],
-        },
+def test_to_dict_product_type():
+    query = BNFQuery(bnf_codes=["1001030U0"], product_type=ProductType.GENERIC)
+    assert query.to_dict() == {
+        "bnf_codes": {"included": ["1001030U0"]},
         "product_type": "generic",
     }
-    query = BNFQuery.from_dict(test_dict)
-    assert query.to_dict() == test_dict
+
+
+def test_to_dict_product_type_all_omitted():
+    query = BNFQuery(bnf_codes=["1001030U0"], product_type=ProductType.ALL)
+    assert query.to_dict() == {"bnf_codes": {"included": ["1001030U0"]}}
+
+
+def test_to_dict_form_routes(dmd_data):
+    query = BNFQuery(form_route_ids=["1"])
+    assert query.to_dict() == {
+        "bnf_codes": {"included": []},
+        "form_routes": ["tablet.oral"],
+    }
+
+
+def test_to_dict_form_routes_excluded(dmd_data):
+    query = BNFQuery(form_route_ids_excluded=["24"])
+    assert query.to_dict() == {
+        "bnf_codes": {"included": []},
+        "form_routes_excluded": ["solutioninjection.intravenous"],
+    }
+
+
+def test_to_dict_ingredient_ids():
+    query = BNFQuery(ingredient_ids=["53034005"])
+    assert query.to_dict() == {
+        "bnf_codes": {"included": []},
+        "ingredient_ids": ["53034005"],
+    }
+
+
+def test_to_dict_ingredient_ids_excluded():
+    query = BNFQuery(ingredient_ids_excluded=["53034005"])
+    assert query.to_dict() == {
+        "bnf_codes": {"included": []},
+        "ingredient_ids_excluded": ["53034005"],
+    }
+
+
+def test_to_dict_vtm_ids():
+    query = BNFQuery(vtm_ids=["15219611000001105"])
+    assert query.to_dict() == {
+        "bnf_codes": {"included": []},
+        "vtm_ids": ["15219611000001105"],
+    }
+
+
+def test_to_dict_vtm_ids_excluded():
+    query = BNFQuery(vtm_ids_excluded=["108502004"])
+    assert query.to_dict() == {
+        "bnf_codes": {"included": []},
+        "vtm_ids_excluded": ["108502004"],
+    }
+
+
+def test_from_dict_bnf_codes_included():
+    query = BNFQuery.from_dict({"bnf_codes": {"included": ["1001030U0"]}})
+    assert query == BNFQuery(bnf_codes=["1001030U0"])
+
+
+def test_from_dict_bnf_codes_excluded():
+    query = BNFQuery.from_dict(
+        {"bnf_codes": {"included": ["1001030U0"], "excluded": ["1001030U0AAABAB"]}}
+    )
+    assert query == BNFQuery(
+        bnf_codes=["1001030U0"], bnf_codes_excluded=["1001030U0AAABAB"]
+    )
+
+
+def test_from_dict_product_type():
+    query = BNFQuery.from_dict({"product_type": "generic"})
+    assert query == BNFQuery(product_type=ProductType.GENERIC)
+
+
+def test_from_dict_form_routes(dmd_data):
+    query = BNFQuery.from_dict({"form_routes": ["tablet.oral"]})
+    assert query == BNFQuery(form_route_ids=["1"])
+
+
+def test_from_dict_forms(dmd_data):
+    query = BNFQuery.from_dict({"forms": ["pressurizedinhalation"]})
+    assert query == BNFQuery(form_route_ids=["4"])
+
+
+def test_from_dict_routes(dmd_data):
+    query = BNFQuery.from_dict({"routes": ["subretinal"]})
+    assert query == BNFQuery(form_route_ids=["320"])
+
+
+def test_from_dict_form_routes_excluded(dmd_data):
+    query = BNFQuery.from_dict(
+        {"form_routes_excluded": ["solutioninjection.intravenous"]}
+    )
+    assert query == BNFQuery(form_route_ids_excluded=["24"])
+
+
+def test_from_dict_forms_excluded(dmd_data):
+    query = BNFQuery.from_dict({"forms_excluded": ["pressurizedinhalation"]})
+    assert query == BNFQuery(form_route_ids_excluded=["4"])
+
+
+def test_from_dict_routes_excluded(dmd_data):
+    query = BNFQuery.from_dict({"routes_excluded": ["subretinal"]})
+    assert query == BNFQuery(form_route_ids_excluded=["320"])
+
+
+def test_from_dict_ingredient_ids():
+    query = BNFQuery.from_dict({"ingredient_ids": [53034005]})
+    assert query == BNFQuery(ingredient_ids=["53034005"])
+
+
+def test_from_dict_ingredient_ids_excluded():
+    query = BNFQuery.from_dict({"ingredient_ids_excluded": [53034005]})
+    assert query == BNFQuery(ingredient_ids_excluded=["53034005"])
+
+
+def test_from_dict_vtm_ids():
+    query = BNFQuery.from_dict({"vtm_ids": [15219611000001105]})
+    assert query == BNFQuery(vtm_ids=["15219611000001105"])
+
+
+def test_from_dict_vtm_ids_excluded():
+    query = BNFQuery.from_dict({"vtm_ids_excluded": [108502004]})
+    assert query == BNFQuery(vtm_ids_excluded=["108502004"])
 
 
 def test_from_dict_form_route(dmd_data):
@@ -643,6 +768,21 @@ def test_from_dict_form_route(dmd_data):
             "included": ["0203020C0AAAAAA"],
         },
         "form_routes": ["solutioninjection.intravenous"],
+    }
+    query = BNFQuery.from_dict(test_dict)
+    assert query.to_dict() == test_dict
+
+
+def test_from_dict_form_route_excluded(dmd_data):
+    # The following appears in the dm+d -> BNF data/mapping data
+    BNFCode(code="0203020C0AAAAAA", level=BNFCode.Level.PRESENTATION).save()
+
+    test_dict = {
+        "bnf_codes": {
+            "included": ["0203020C0AAAAAA"],
+        },
+        "form_routes": ["solutioninjection.intravenous"],
+        "form_routes_excluded": ["suspension.oral"],
     }
     query = BNFQuery.from_dict(test_dict)
     assert query.to_dict() == test_dict
@@ -699,14 +839,3 @@ def test_get_form_route_ids_for_invalid_form_routes(dmd_data):
         _get_form_route_ids_for_forms_and_routes(
             form_routes=[], forms=[], routes=["interstellar"]
         )
-
-
-def test_from_dict_ingredient():
-    test_dict = {
-        "ingredient_ids": ["53034005"],
-    }
-
-    query = BNFQuery.from_dict(test_dict)
-    computed_dict = query.to_dict()
-
-    assert computed_dict["ingredient_ids"] == ["53034005"]

--- a/tests/data/test_bnf_query_round_trips.py
+++ b/tests/data/test_bnf_query_round_trips.py
@@ -1,0 +1,49 @@
+import string
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from openprescribing.data.bnf_query import (
+    BNFQuery,
+    ProductType,
+)
+
+
+# Tokens used to build arbitrary id/code values. They must be non-empty (an empty
+# tuple is omitted by the serializers and reconstructed as an empty tuple, but a tuple
+# containing an empty string is not) and must not contain commas (the separator used by
+# to_params/from_params).
+tokens = st.text(alphabet=string.ascii_letters + string.digits, min_size=1, max_size=8)
+token_tuples = st.lists(tokens, max_size=4).map(tuple)
+
+
+@st.composite
+def bnf_queries(draw, *, include_form_routes=True):
+    """Build an arbitrary BNFQuery.
+
+    form_route_ids are serialized to descriptions and back via the database by
+    to_dict/from_dict, so they can only be included for serializers that round-trip
+    them as raw, order-preserving ids (i.e. to_params/from_params).
+    """
+
+    return BNFQuery(
+        bnf_codes=draw(token_tuples),
+        bnf_codes_excluded=draw(token_tuples),
+        product_type=draw(st.sampled_from(list(ProductType))),
+        form_route_ids=draw(token_tuples) if include_form_routes else (),
+        form_route_ids_excluded=draw(token_tuples) if include_form_routes else (),
+        ingredient_ids=draw(token_tuples),
+        ingredient_ids_excluded=draw(token_tuples),
+        vtm_ids=draw(token_tuples),
+        vtm_ids_excluded=draw(token_tuples),
+    )
+
+
+@given(query=bnf_queries())
+def test_params_round_trip(query):
+    assert BNFQuery.from_params("ntr", query.to_params("ntr")) == query
+
+
+@given(query=bnf_queries(include_form_routes=False))
+def test_dict_round_trip(query):
+    assert BNFQuery.from_dict(query.to_dict()) == query

--- a/uv.lock
+++ b/uv.lock
@@ -579,6 +579,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.152.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/fb/a5651eb0cd03ecee644e8f4d8cd2027b40a08bf1488f46201e794aebe9b5/hypothesis-6.152.9.tar.gz", hash = "sha256:de4711d69ce3a18009047c3b44882810fd0c0348c1558e920a4b0d2c45f59e1e", size = 472009, upload-time = "2026-05-19T17:10:19.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/d9/40ef7ed22f0c45c2316467edb9afb8fc172cd089cb329c0ee6da6b74416c/hypothesis-6.152.9-py3-none-any.whl", hash = "sha256:9c4fdccb1eac0b12ec740c12290d0e6a0bea3526a3f0bf812b7643bb563c2d8b", size = 538148, upload-time = "2026-05-19T17:10:16.131Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -803,6 +815,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "hypothesis" },
     { name = "playwright" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -840,6 +853,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.10.6" },
+    { name = "hypothesis", specifier = ">=6.152.9" },
     { name = "playwright", specifier = ">=1.56.0" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.4.1" },
@@ -1578,6 +1592,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
When an Analysis was serialised via .to_dict, some fields
(form_route_ids_excluded, ingredient_ids_excluded, vtm_ids,
vtm_ids_excluded) were not included in the resulting dict.

In #324, we changed how an Analysis was serialised, using .to_dict
instead of .to_params.  This means that any analyses that use these
fields were incorrect.