### PR TITLE
Add "Prescribing by medication" chart type

### DIFF
--- a/openprescribing/web/analysis_presentation.py
+++ b/openprescribing/web/analysis_presentation.py
@@ -29,3 +29,4 @@ class ChartType(StrEnum):
     DECILES = "deciles"
     ALL_ORGS_LINE = "all-orgs-line"
     ALL_ORGS_DOTS = "all-orgs-dots"
+    MEDICATIONS = "medications"

--- a/openprescribing/web/charts.py
+++ b/openprescribing/web/charts.py
@@ -4,7 +4,7 @@ from openprescribing.data.bnf_query import BNFQuery
 from openprescribing.data.list_size_query import ListSizeQuery
 
 
-def build_chart_spec(analysis):
+def build_org_chart_spec(analysis):
     if not analysis:
         return
 

--- a/openprescribing/web/charts.py
+++ b/openprescribing/web/charts.py
@@ -57,3 +57,57 @@ def build_org_chart_spec(analysis):
     ).properties(width="container", height=360)
 
     return chart_spec.to_dict()
+
+
+def build_medications_chart_spec(analysis):
+    """Build the spec for the "by medication" stacked area chart.
+
+    Unlike the deciles/all-orgs charts this shows absolute item counts (not a ratio)
+    broken down by medication, so it needs its own y-axis and colour legend.  We
+    therefore give it a separate spec which the frontend embeds in place of the combined
+    chart, rather than adding it as a layer to that chart (which would leak its axis and
+    legend onto the other chart types).
+    """
+    if not analysis:
+        return
+
+    x = alt.X("month:T", title="Month", axis=alt.Axis(format="%Y %b"))
+    chart_spec = (
+        alt.Chart(alt.NamedData("medications"))
+        .mark_area()
+        .transform_joinaggregate(medication_total="sum(value)", groupby=["medication"])
+        .transform_joinaggregate(max_medication_total="max(medication_total)")
+        # Stack "Other" at the bottom, then the named medications largest-first so the
+        # smallest ends up at the top.  Driving both the stack `order` and the colour
+        # legend `sort` from this one field keeps the legend in the same order as the
+        # areas.
+        .transform_calculate(
+            stack_order=(
+                "datum.medication === 'Other' ? -1"
+                " : datum.max_medication_total - datum.medication_total"
+            )
+        )
+        .encode(
+            x=x,
+            y=alt.Y("value:Q", title="Items", stack="zero"),
+            color=alt.Color(
+                "medication:N",
+                title="Medication",
+                sort=alt.EncodingSortField(
+                    field="stack_order", op="max", order="descending"
+                ),
+            ),
+            order=alt.Order("stack_order:Q"),
+            tooltip=[
+                alt.Tooltip("medication:N", title="Medication"),
+                alt.Tooltip("month:T", title="Month", format="%Y %b"),
+                alt.Tooltip("value:Q", title="Items"),
+            ],
+        )
+    )
+
+    chart_spec = chart_spec.configure(
+        autosize={"type": "fit", "resize": True}
+    ).properties(width="container", height=360)
+
+    return chart_spec.to_dict()

--- a/openprescribing/web/charts.py
+++ b/openprescribing/web/charts.py
@@ -59,7 +59,7 @@ def build_org_chart_spec(analysis):
     return chart_spec.to_dict()
 
 
-def build_medications_chart_spec(analysis):
+def build_medications_chart_spec(analysis, largest="top", other="middle"):
     """Build the spec for the "by medication" stacked area chart.
 
     Unlike the deciles/all-orgs charts this shows absolute item counts (not a ratio)
@@ -67,26 +67,47 @@ def build_medications_chart_spec(analysis):
     therefore give it a separate spec which the frontend embeds in place of the combined
     chart, rather than adding it as a layer to that chart (which would leak its axis and
     legend onto the other chart types).
-    """
+
+    `largest` ("top"/"bottom") controls where the largest medication ends up, and
+    `other` ("top"/"middle"/"bottom") controls where the "Other" bucket sits.  "middle"
+    means it is stacked by its own total like any named medication.
+
+    Allowing for customisation of ordering is intended to be a temporary solution to get
+    feedback."""
     if not analysis:
         return
+
+    # Order medications within the stack.  With stack="zero" a larger `stack_order`
+    # sits higher up, so we map each medication's total to a sort key, optionally
+    # forcing "Other" above ("+1") or below ("-1") every named medication.
+    if largest == "top":
+        named_order = "datum.medication_total"
+        other_top = "datum.max_medication_total + 1"
+        other_bottom = "datum.min_medication_total - 1"
+    else:  # pragma: no cover
+        named_order = "-datum.medication_total"
+        other_top = "-datum.min_medication_total + 1"
+        other_bottom = "-datum.max_medication_total - 1"
+
+    if other == "top":  # pragma: no cover
+        stack_order = f"datum.medication === 'Other' ? {other_top} : {named_order}"
+    elif other == "bottom":  # pragma: no cover
+        stack_order = f"datum.medication === 'Other' ? {other_bottom} : {named_order}"
+    else:
+        stack_order = named_order
 
     x = alt.X("month:T", title="Month", axis=alt.Axis(format="%Y %b"))
     chart_spec = (
         alt.Chart(alt.NamedData("medications"))
         .mark_area()
         .transform_joinaggregate(medication_total="sum(value)", groupby=["medication"])
-        .transform_joinaggregate(max_medication_total="max(medication_total)")
-        # Stack "Other" at the bottom, then the named medications largest-first so the
-        # smallest ends up at the top.  Driving both the stack `order` and the colour
-        # legend `sort` from this one field keeps the legend in the same order as the
-        # areas.
-        .transform_calculate(
-            stack_order=(
-                "datum.medication === 'Other' ? -1"
-                " : datum.max_medication_total - datum.medication_total"
-            )
+        .transform_joinaggregate(
+            max_medication_total="max(medication_total)",
+            min_medication_total="min(medication_total)",
         )
+        # Driving both the stack `order` and the colour legend `sort` from this one
+        # field keeps the legend in the same order as the areas.
+        .transform_calculate(stack_order=stack_order)
         .encode(
             x=x,
             y=alt.Y("value:Q", title="Items", stack="zero"),

--- a/openprescribing/web/static/js/prescribing-chart.js
+++ b/openprescribing/web/static/js/prescribing-chart.js
@@ -2,13 +2,11 @@ const orgs = JSON.parse(document.getElementById("orgs").textContent);
 const orgTypes = Object.fromEntries(
   JSON.parse(document.getElementById("org-types").textContent),
 );
-const chartSpec = JSON.parse(document.getElementById("chart").textContent);
-
-const prescribingDecilesUrl = JSON.parse(
-  document.getElementById("prescribing-deciles-url").textContent,
+const chartSpecs = JSON.parse(
+  document.getElementById("chart-specs").textContent,
 );
-const prescribingAllOrgsUrl = JSON.parse(
-  document.getElementById("prescribing-all-orgs-url").textContent,
+const prescribingUrls = JSON.parse(
+  document.getElementById("prescribing-urls").textContent,
 );
 
 const chartConfigs = {
@@ -17,17 +15,17 @@ const chartConfigs = {
   //  - responseKey: the key in the URL response that contains the chart data
   //  - vegaDatasetName: the name of the dataset in the Vega chart spec
   deciles: {
-    apiUrl: prescribingDecilesUrl,
+    apiUrl: prescribingUrls.deciles,
     responseKey: "deciles",
     vegaDatasetName: "deciles",
   },
   "all-orgs-line": {
-    apiUrl: prescribingAllOrgsUrl,
+    apiUrl: prescribingUrls.all_orgs,
     responseKey: "all_orgs",
     vegaDatasetName: "all_orgs_line",
   },
   "all-orgs-dots": {
-    apiUrl: prescribingAllOrgsUrl,
+    apiUrl: prescribingUrls.all_orgs,
     responseKey: "all_orgs",
     vegaDatasetName: "all_orgs_dots",
   },
@@ -44,7 +42,7 @@ const initialisePage = async () => {
 
   setChartType(chartTypeFromUrl());
 
-  chartResult = await vegaEmbed(chartContainer, chartSpec, { renderer: "svg" });
+  chartResult = await vegaEmbed(chartContainer, chartSpecs["org"], { renderer: "svg" });
 
   window.addEventListener("popstate", () => {
     setChartType(chartTypeFromUrl());

--- a/openprescribing/web/static/js/prescribing-chart.js
+++ b/openprescribing/web/static/js/prescribing-chart.js
@@ -14,35 +14,38 @@ const chartConfigs = {
   //  - apiUrl: the URL that returns the chart data
   //  - responseKey: the key in the URL response that contains the chart data
   //  - vegaDatasetName: the name of the dataset in the Vega chart spec
+  //  - specName: the key in chartSpecs of the Vega spec to embed
   deciles: {
     apiUrl: prescribingUrls.deciles,
     responseKey: "deciles",
     vegaDatasetName: "deciles",
+    specName: "org",
   },
   "all-orgs-line": {
     apiUrl: prescribingUrls.all_orgs,
     responseKey: "all_orgs",
     vegaDatasetName: "all_orgs_line",
+    specName: "org",
   },
   "all-orgs-dots": {
     apiUrl: prescribingUrls.all_orgs,
     responseKey: "all_orgs",
     vegaDatasetName: "all_orgs_dots",
+    specName: "org",
   },
 };
 
 const chartLoading = document.querySelector("#chart-loading");
 const chartContainer = document.querySelector("#chart-container");
 
-// We'll store the Vega chart result here.
+// We'll store the Vega chart result, and the name of the spec it was built from, here.
 let chartResult;
+let currentSpecName;
 
 const initialisePage = async () => {
   // Set the chart type and set up event handlers.
 
   setChartType(chartTypeFromUrl());
-
-  chartResult = await vegaEmbed(chartContainer, chartSpecs["org"], { renderer: "svg" });
 
   window.addEventListener("popstate", () => {
     setChartType(chartTypeFromUrl());
@@ -112,48 +115,63 @@ const setChartType = (chartType, pushHistory = false) => {
   }
 };
 
-const updateChart = (chartConfig) => {
-  const { apiUrl, responseKey, vegaDatasetName } = chartConfig;
+// Embed the named spec, reusing the existing view if it's already embedded. Chart types
+// that share a spec (deciles/all-orgs) avoid re-embedding.
+const embedSpec = async (specName) => {
+  if (specName === currentSpecName) {
+    return;
+  }
+  currentSpecName = specName;
+  if (chartResult) {
+    // Tear down the previous view before replacing it, so we don't leak its listeners.
+    chartResult.finalize();
+  }
+  chartResult = await vegaEmbed(chartContainer, chartSpecs[specName], {
+    renderer: "svg",
+  });
+};
+
+const updateChart = async (chartConfig) => {
+  const { apiUrl, responseKey, vegaDatasetName, specName } = chartConfig;
 
   chartLoading.textContent = "Loading chart...";
-  fetch(apiUrl)
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`Failed to fetch chart data: ${response.status}`);
-      }
-      return response.json();
-    })
-    .then((response) => {
-      response[responseKey].forEach((record) => {
+  try {
+    await embedSpec(specName);
+
+    const response = await fetch(apiUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch chart data: ${response.status}`);
+    }
+    const data = await response.json();
+
+    data[responseKey].forEach((record) => {
+      record.month = new Date(record.month);
+    });
+    if (data.org) {
+      data.org.forEach((record) => {
         record.month = new Date(record.month);
       });
-      if (response.org) {
-        response.org.forEach((record) => {
-          record.month = new Date(record.month);
-        });
-      }
-      const datasetNames = chartResult.spec.layer.map(
-        (layer) => layer.data.name,
-      );
-      datasetNames.forEach((datasetName) => {
-        chartResult.view.remove(datasetName, () => true);
-      });
-      chartResult.view.insert(vegaDatasetName, response[responseKey]);
-      if (response.org) {
-        chartResult.view.insert("org", response.org);
-      }
-      chartResult.view.run();
-
-      chartLoading.classList.add("invisible");
-      chartContainer.classList.add("visible");
-      chartLoading.classList.remove("visible");
-      chartContainer.classList.remove("invisible");
-    })
-    .catch((error) => {
-      console.error("Unable to render deciles chart", error);
-      chartLoading.textContent =
-        "Unable to load chart data. Please try again later.";
+    }
+    // The combined ("org") spec carries its named datasets on each layer.
+    const datasetNames = chartResult.spec.layer.map((layer) => layer.data.name);
+    datasetNames.forEach((datasetName) => {
+      chartResult.view.remove(datasetName, () => true);
     });
+    chartResult.view.insert(vegaDatasetName, data[responseKey]);
+    if (data.org) {
+      chartResult.view.insert("org", data.org);
+    }
+    chartResult.view.run();
+
+    chartLoading.classList.add("invisible");
+    chartContainer.classList.add("visible");
+    chartLoading.classList.remove("visible");
+    chartContainer.classList.remove("invisible");
+  } catch (error) {
+    console.error("Unable to render chart", error);
+    chartLoading.textContent =
+      "Unable to load chart data. Please try again later.";
+  }
 };
 
 const updateUrl = (chartType) => {

--- a/openprescribing/web/static/js/prescribing-chart.js
+++ b/openprescribing/web/static/js/prescribing-chart.js
@@ -154,6 +154,7 @@ const updateChart = async (chartConfig) => {
   const { apiUrl, responseKey, vegaDatasetName, specName } = chartConfig;
 
   chartLoading.textContent = "Loading chart...";
+  showLoading();
   try {
     await embedSpec(specName);
 
@@ -185,15 +186,26 @@ const updateChart = async (chartConfig) => {
     }
     chartResult.view.run();
 
-    chartLoading.classList.add("invisible");
-    chartContainer.classList.add("visible");
-    chartLoading.classList.remove("visible");
-    chartContainer.classList.remove("invisible");
+    showChart();
   } catch (error) {
     console.error("Unable to render chart", error);
     chartLoading.textContent =
       "Unable to load chart data. Please try again later.";
   }
+};
+
+const showLoading = () => {
+  chartLoading.classList.add("visible");
+  chartContainer.classList.add("invisible");
+  chartLoading.classList.remove("invisible");
+  chartContainer.classList.remove("visible");
+};
+
+const showChart = () => {
+  chartLoading.classList.add("invisible");
+  chartContainer.classList.add("visible");
+  chartLoading.classList.remove("visible");
+  chartContainer.classList.remove("invisible");
 };
 
 const updateUrl = (chartType) => {

--- a/openprescribing/web/static/js/prescribing-chart.js
+++ b/openprescribing/web/static/js/prescribing-chart.js
@@ -114,11 +114,23 @@ const setupOrgSearch = () => {
 
 const setChartType = (chartType, pushHistory = false) => {
   document.getElementById(chartType).checked = true;
+  updateDenominatorVisibility(chartType);
   updateChart(chartConfigs[chartType]);
 
   if (pushHistory) {
     updateUrl(chartType);
   }
+};
+
+const updateDenominatorVisibility = (chartType) => {
+  // The medications chart is derived from the numerator query alone, but it is
+  // generated from an Analysis object that may have a denominator query.  The
+  // denominator description and the numerator/denominator intersection table aren't
+  // relevant and should be hidden.
+  ["denominator-section", "presentations-section"].forEach((id) => {
+    const el = document.getElementById(id);
+    el.classList.toggle("d-none", chartType === "medications");
+  });
 };
 
 // Embed the named spec, reusing the existing view if it's already embedded. Chart types

--- a/openprescribing/web/static/js/prescribing-chart.js
+++ b/openprescribing/web/static/js/prescribing-chart.js
@@ -33,6 +33,12 @@ const chartConfigs = {
     vegaDatasetName: "all_orgs_dots",
     specName: "org",
   },
+  medications: {
+    apiUrl: prescribingUrls.medications,
+    responseKey: "medications",
+    vegaDatasetName: "medications",
+    specName: "medications",
+  },
 };
 
 const chartLoading = document.querySelector("#chart-loading");
@@ -116,7 +122,8 @@ const setChartType = (chartType, pushHistory = false) => {
 };
 
 // Embed the named spec, reusing the existing view if it's already embedded. Chart types
-// that share a spec (deciles/all-orgs) avoid re-embedding.
+// that share a spec (deciles/all-orgs) avoid re-embedding; switching to/from the
+// medications chart embeds its separate spec in place of the combined one.
 const embedSpec = async (specName) => {
   if (specName === currentSpecName) {
     return;
@@ -152,8 +159,11 @@ const updateChart = async (chartConfig) => {
         record.month = new Date(record.month);
       });
     }
-    // The combined ("org") spec carries its named datasets on each layer.
-    const datasetNames = chartResult.spec.layer.map((layer) => layer.data.name);
+    // The combined ("org") spec carries its named datasets on each layer; the
+    // single-mark medications spec carries its one dataset at the top level.
+    const datasetNames = chartResult.spec.layer
+      ? chartResult.spec.layer.map((layer) => layer.data.name)
+      : [chartResult.spec.data.name];
     datasetNames.forEach((datasetName) => {
       chartResult.view.remove(datasetName, () => true);
     });

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -248,7 +248,7 @@
 {% endblock %}
 
 {% block extra_js %}
-{% if chart_spec %}
+{% if analysis %}
 {{ orgs|json_script:"orgs" }}
 {{ org_types|json_script:"org-types" }}
 {{ prescribing_deciles_url|json_script:"prescribing-deciles-url" }}

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -128,13 +128,13 @@
                         <div class="col-12">
                         </div>
                     </div>
-                    <div class="row mt-3">
+                    <div class="row mt-3" id="numerator-section">
                         <div class="col-12">
                             <h2 class="h5">Numerator</h2>
                             {% include "./_search_description.html" with description=analysis.ntr_query.describe %}
                         </div>
                     </div>
-                    <div class="row">
+                    <div class="row" id="denominator-section">
                         <div class="col-12">
                             <h2 class="h5">Denominator</h2>
                             {% include "./_search_description.html" with description=analysis.dtr_query.describe %}
@@ -148,7 +148,7 @@
                         </div>
                     </div>
                     {% endif %}
-                    <div class="row mt-3">
+                    <div class="row mt-3" id="presentations-section">
                         <div class="col-12">
                             <p>
                                 <button

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="row">
     {% if analysis %}
-    <div class="col-lg-5">
+    <div class="col-lg-4">
         {% if measure %}
         <div class="card mb-4">
             <div class="card-body">
@@ -112,7 +112,7 @@
         </div>
     </div>
 
-    <div class="col-lg-7">
+    <div class="col-lg-8">
         <div class="card h-100">
             <div class="card-body">
                 <h1 class="h3">Prescribing data</h1>

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -249,9 +249,8 @@
 {% if analysis %}
 {{ orgs|json_script:"orgs" }}
 {{ org_types|json_script:"org-types" }}
-{{ prescribing_deciles_url|json_script:"prescribing-deciles-url" }}
-{{ prescribing_all_orgs_url|json_script:"prescribing-all-orgs-url" }}
-{{ chart_spec|json_script:"chart" }}
+{{ prescribing_urls|json_script:"prescribing-urls" }}
+{{ chart_specs|json_script:"chart-specs" }}
 <script src="https://cdn.jsdelivr.net/npm/vega@6.2.0"></script>
 <script src="https://cdn.jsdelivr.net/npm/vega-lite@6.4.1"></script>
 <script src="https://cdn.jsdelivr.net/npm/vega-embed@7.0.2"></script>

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -140,7 +140,6 @@
                         </div>
                     </div>
                     {% endif %}
-                    {% if ntr_dtr_intersection_table %}
                     <div class="row mt-3">
                         <div class="col-12">
                             <p>
@@ -160,7 +159,6 @@
                             </div>
                         </div>
                     </div>
-                    {% endif %}
                 </div>
             </div>
         </div>

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -91,6 +91,14 @@
                              {% if analysis_presentation.chart_type == "all-orgs-dots" %}checked{% endif %}
                          >
                          <label for="all-orgs-dots">All {{ org_type_label }}s (dots chart)</label><br>
+                         <input
+                             type="radio"
+                             id="medications"
+                             name="chart_type"
+                             value="medications"
+                             {% if analysis_presentation.chart_type == "medications" %}checked{% endif %}
+                         >
+                         <label for="medications">Prescribing by medication</label><br>
                      </fieldset>
                 </section>
 

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -69,9 +69,13 @@ def _build_analysis_context(analysis):
         "org_type_label": org_type.label,
         "build_analysis_url": build_analysis_url,
         "download_analysis_url": download_analysis_url,
-        "prescribing_deciles_url": deciles_api_url,
-        "prescribing_all_orgs_url": all_orgs_api_url,
-        "chart_spec": build_chart_spec(analysis),
+        "prescribing_urls": {
+            "deciles": deciles_api_url,
+            "all_orgs": all_orgs_api_url,
+        },
+        "chart_specs": {
+            "org": build_chart_spec(analysis),
+        },
     }
 
     return ctx

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -15,7 +15,7 @@ from openprescribing.data.measures import all_measure_details, load_measure
 from openprescribing.data.models import BNFCode, Org
 
 from .analysis_presentation import AnalysisPresentation
-from .charts import build_org_chart_spec
+from .charts import build_medications_chart_spec, build_org_chart_spec
 from .models import Feedback
 from .presenters import (
     make_bnf_table,
@@ -30,6 +30,7 @@ def _build_analysis_context(analysis):
     download_analysis_url = reverse("download-analysis")
     deciles_api_url = None
     all_orgs_api_url = None
+    medications_api_url = None
     org = None
     ntr_dtr_intersection_table = None
 
@@ -55,6 +56,9 @@ def _build_analysis_context(analysis):
         all_orgs_api_url = (
             f"{reverse('api_prescribing_all_orgs')}?{url_parameters_json}"
         )
+        medications_api_url = (
+            f"{reverse('api_prescribing_medications')}?{url_parameters_json}"
+        )
 
     orgs = make_orgs()
 
@@ -72,9 +76,11 @@ def _build_analysis_context(analysis):
         "prescribing_urls": {
             "deciles": deciles_api_url,
             "all_orgs": all_orgs_api_url,
+            "medications": medications_api_url,
         },
         "chart_specs": {
             "org": build_org_chart_spec(analysis),
+            "medications": build_medications_chart_spec(analysis),
         },
     }
 

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -25,7 +25,7 @@ from .presenters import (
 )
 
 
-def _build_analysis_context(analysis):
+def _build_analysis_context(analysis, medications_order):
     build_analysis_url = reverse("build-analysis")
     download_analysis_url = reverse("download-analysis")
     deciles_api_url = None
@@ -80,7 +80,7 @@ def _build_analysis_context(analysis):
         },
         "chart_specs": {
             "org": build_org_chart_spec(analysis),
-            "medications": build_medications_chart_spec(analysis),
+            "medications": build_medications_chart_spec(analysis, **medications_order),
         },
     }
 
@@ -95,11 +95,24 @@ def analysis(request):
     else:
         analysis = None
 
-    ctx = _build_analysis_context(analysis)
+    ctx = _build_analysis_context(analysis, _medications_order(request))
     ctx["measure"] = False
     ctx["analysis_presentation"] = analysis_presentation
 
     return render(request, "analysis.html", ctx)
+
+
+def _medications_order(request):
+    """Pull the "by medication" chart ordering from the query string, e.g.
+    ?largest=bottom&other=top.  Unknown values fall back to the chart's defaults.
+
+    Intended to be a temporary solution to get feedback.
+    """
+    order = {}
+    for key in ("largest", "other"):
+        if key in request.GET:  # pragma: no cover
+            order[key] = request.GET[key]
+    return order
 
 
 def build_analysis(request):
@@ -132,7 +145,7 @@ def measure(request, measure_name):
     analysis_dict["org_id"] = request.GET.get("org_id")
     analysis = Analysis.from_dict(analysis_dict)
 
-    ctx = _build_analysis_context(analysis)
+    ctx = _build_analysis_context(analysis, _medications_order(request))
     ctx["measure"] = True
     ctx["measure_title"] = analysis_dict["metadata"]["title"]
     ctx["why_it_matters"] = markdown.markdown(

--- a/openprescribing/web/views.py
+++ b/openprescribing/web/views.py
@@ -15,7 +15,7 @@ from openprescribing.data.measures import all_measure_details, load_measure
 from openprescribing.data.models import BNFCode, Org
 
 from .analysis_presentation import AnalysisPresentation
-from .charts import build_chart_spec
+from .charts import build_org_chart_spec
 from .models import Feedback
 from .presenters import (
     make_bnf_table,
@@ -74,7 +74,7 @@ def _build_analysis_context(analysis):
             "all_orgs": all_orgs_api_url,
         },
         "chart_specs": {
-            "org": build_chart_spec(analysis),
+            "org": build_org_chart_spec(analysis),
         },
     }
 

--- a/tests/functional/test_analysis.py
+++ b/tests/functional/test_analysis.py
@@ -37,6 +37,7 @@ def test_analysis(live_server, page, sample_data, settings, tmp_path):
     for chart_type, endpoint in [
         ("all-orgs-line", "/api/prescribing-all-orgs/"),
         ("all-orgs-dots", "/api/prescribing-all-orgs/"),
+        ("medications", "/api/prescribing-medications/"),
         # Visit deciles last, because that is the first chart type to be shown.
         ("deciles", "/api/prescribing-deciles/"),
     ]:

--- a/tests/functional/test_analysis.py
+++ b/tests/functional/test_analysis.py
@@ -30,3 +30,20 @@ def test_analysis(live_server, page, sample_data, settings, tmp_path):
 
     expect(page).to_have_url(live_server.url + "/?ntr_vtm_ids=108502004")
     expect(page.locator("#chart-container")).to_be_attached()
+
+    # Clicking each chart type in turn fetches fresh data from the API and renders a
+    # chart.  The container is hidden until its data loads and an SVG is drawn, so a
+    # visible SVG confirms the chart rendered successfully.
+    for chart_type, endpoint in [
+        ("all-orgs-line", "/api/prescribing-all-orgs/"),
+        ("all-orgs-dots", "/api/prescribing-all-orgs/"),
+        # Visit deciles last, because that is the first chart type to be shown.
+        ("deciles", "/api/prescribing-deciles/"),
+    ]:
+        with page.expect_response(f"**{endpoint}**") as info:
+            page.locator(f"#{chart_type}").check()
+        assert info.value.ok
+
+        expect(page.locator(f"#{chart_type}")).to_be_checked()
+        expect(page.locator("#chart-container")).to_be_visible()
+        expect(page.locator("#chart-container svg.marks")).to_be_visible()

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -18,7 +18,7 @@ def test_analysis(client, sample_data):
     assert rsp.status_code == 200
     assert (
         "numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0"
-        in rsp.context["prescribing_deciles_url"]
+        in rsp.context["prescribing_urls"]["deciles"]
     )
     assert rsp.context["analysis_presentation"].chart_type == ChartType.DECILES
     assert rsp.context["org_type_label"] == "ICB"
@@ -27,14 +27,14 @@ def test_analysis(client, sample_data):
     assert rsp.status_code == 200
     assert (
         "denominator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001"
-        in rsp.context["prescribing_deciles_url"]
+        in rsp.context["prescribing_urls"]["deciles"]
     )
 
     rsp = client.get("?ntr_bnf_codes=1001030U0AAABAB,1001030U0AAABAB")
     assert rsp.status_code == 200
     assert (
         "numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0AAABAB%22%2C+%221001030U0AAABAB"
-        in rsp.context["prescribing_deciles_url"]
+        in rsp.context["prescribing_urls"]["deciles"]
     )
 
     rsp = client.get(
@@ -43,14 +43,14 @@ def test_analysis(client, sample_data):
     assert rsp.status_code == 200
     assert (
         "numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0AA%22%5D%2C+%22excluded%22%3A+%5B%221001030U0AAABAB"
-        in rsp.context["prescribing_deciles_url"]
+        in rsp.context["prescribing_urls"]["deciles"]
     )
 
     rsp = client.get(
         "?ntr_bnf_codes=1001030U0AA&ntr_bnf_codes_excluded=1001030U0AAABAB&org_id=PRA00"
     )
     assert rsp.status_code == 200
-    assert "org_id%22%3A+%22PRA00" in rsp.context["prescribing_deciles_url"]
+    assert "org_id%22%3A+%22PRA00" in rsp.context["prescribing_urls"]["deciles"]
     assert rsp.context["org_type_label"] == "Practice"
 
     rsp = client.get("?ntr_bnf_codes=1001030U0&chart_type=all-orgs-line")

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -62,6 +62,10 @@ def test_analysis(client, sample_data):
     assert rsp.status_code == 200
     assert rsp.context["analysis_presentation"].chart_type == ChartType.DECILES
 
+    rsp = client.get("?ntr_bnf_codes=1001030U0&chart_type=medications")
+    assert rsp.status_code == 200
+    assert rsp.context["analysis_presentation"].chart_type == ChartType.MEDICATIONS
+
 
 def test_analysis_build(client, sample_data):
     rsp = client.get("/analysis/build/")


### PR DESCRIPTION
This chart shows the number of items prescribed nationally for each
medication that matches the numerator query of an analysis.  The
denominator query is ignored.

I think we will want to rethink this.  For instance, we may want to
forbid this chart type for analyses with denominators, or only support
a list-size denominator.

But I'd like to get this in front of users for feedback.

<img width="1317" height="570" alt="image" src="https://github.com/user-attachments/assets/2095c3d5-2e88-41ab-a168-49e565d12784" />
