### PR TITLE
Rework YAML analysis format output param as options

### DIFF
--- a/measure_definitions/aafpercent.yaml
+++ b/measure_definitions/aafpercent.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: quantity
-  denominator: quantity
+options:
+  type: prescribing_vs_prescribing
+  output_value: quantity
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/all_antibiotics.yaml
+++ b/measure_definitions/all_antibiotics.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: caroline.acuda@phc.ox.ac.uk
   date_reviewed: 2026-03-23
   date_next_review: 2028-03-23
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       routes:

--- a/measure_definitions/amox_500_15_caps.yaml
+++ b/measure_definitions/amox_500_15_caps.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/aware_antibiotics.yaml
+++ b/measure_definitions/aware_antibiotics.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/bdzadq.yaml
+++ b/measure_definitions/bdzadq.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/bdzper1000.yaml
+++ b/measure_definitions/bdzper1000.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/broad_spectrum.yaml
+++ b/measure_definitions/broad_spectrum.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: andrew.brown@phc.ox.ac.uk
   date_reviewed: 2026-03-23
   date_next_review: 2028-03-23
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       routes:
@@ -33,5 +33,5 @@ queries:
             - "0501" #Antibacterial drugs
           excluded:
             - "050109" # Exclude antituberculosis drugs
-            - "050110" # Exclude antileprotic drugs 
-            - "0501130H0" # Exclude methenamine as this is a urinary antiseptic 
+            - "050110" # Exclude antileprotic drugs
+            - "0501130H0" # Exclude methenamine as this is a urinary antiseptic

--- a/measure_definitions/broad_spectrum_list.yaml
+++ b/measure_definitions/broad_spectrum_list.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       routes:
@@ -25,4 +25,3 @@ queries:
           - "0501013K0" # Co-Amoxiclav
           - "0501021" # Cephalosporins
           - "050112" # Quinolones
-

--- a/measure_definitions/carbon_salbutamol.yaml
+++ b/measure_definitions/carbon_salbutamol.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/cgm_sensors.yaml
+++ b/measure_definitions/cgm_sensors.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/ciclosporin.yaml
+++ b/measure_definitions/ciclosporin.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/cmpaperpt.yaml
+++ b/measure_definitions/cmpaperpt.yaml
@@ -11,9 +11,10 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: custom
+options:
+  # nb. this should be a custom list_size, which we don't currently support
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/dapagliflozin.yaml
+++ b/measure_definitions/dapagliflozin.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/demo-branded-ratio.yaml
+++ b/measure_definitions/demo-branded-ratio.yaml
@@ -3,9 +3,9 @@ metadata:
   tags:
     - demo
   why_it_matters: This one doesn't really matter!
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       product_type: branded

--- a/measure_definitions/demo-penicillin-capsules.yaml
+++ b/measure_definitions/demo-penicillin-capsules.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure which filters by forms
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       forms:

--- a/measure_definitions/demo-penicillin-oral.yaml
+++ b/measure_definitions/demo-penicillin-oral.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure which filters by route
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       routes:

--- a/measure_definitions/demo-penicillin-tablet-oral-2.yaml
+++ b/measure_definitions/demo-penicillin-tablet-oral-2.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure which filters by form & route
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       # These are ANDed together, so this will match only `tablet.oral`

--- a/measure_definitions/demo-penicillin-tablet-oral.yaml
+++ b/measure_definitions/demo-penicillin-tablet-oral.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure which filters by form_route
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       form_routes:

--- a/measure_definitions/demo-penicillin-tablet.yaml
+++ b/measure_definitions/demo-penicillin-tablet.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure which filters by form
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       forms:

--- a/measure_definitions/diltiazem.yaml
+++ b/measure_definitions/diltiazem.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:
@@ -23,11 +23,11 @@ queries:
           - "0206020C0AA" # Diltiazem (generic)
         excluded:
           - "00206020C0AAAAAA" # Diltiazem 60mg modified-release tablets
-          - "00206020C0AAAJAJ" # Diltiazem 60mg modified-release capsules          
+          - "00206020C0AAAJAJ" # Diltiazem 60mg modified-release capsules
     denominator:
       bnf_codes:
         included:
           - "0206020C0" # Diltiazem (brand and generic)
-        excluded: 
+        excluded:
           - "0206020C0%AA" # Diltiazem 60mg modified-release tablets (brand and generic)
           - "0206020C0%AJ" # Diltiazem 60mg modified-release capsules (brand and generic)

--- a/measure_definitions/doacs_nhse.yaml
+++ b/measure_definitions/doacs_nhse.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/doxy_100_6_qty.yaml
+++ b/measure_definitions/doxy_100_6_qty.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/environmental_inhalers.yaml
+++ b/measure_definitions/environmental_inhalers.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       form_routes:
@@ -27,13 +27,12 @@ queries:
         excluded:
           - "0301011R0" # Exclude salbutamol
     denominator:
-      form_routes: 
+      form_routes:
         - "pressurizedinhalation.inhalation"
         - "powderinhalation.inhalation"
-        - "inhalationsolution.inhalation" 
+        - "inhalationsolution.inhalation"
       bnf_codes:
         included:
-          - "03" # BNF Chapter 3  
+          - "03" # BNF Chapter 3
         excluded:
-          - "0301011R0" # Exclude salbutamol    
-       
+          - "0301011R0" # Exclude salbutamol

--- a/measure_definitions/excess_pens.yaml
+++ b/measure_definitions/excess_pens.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/fluoroquinolones_list.yaml
+++ b/measure_definitions/fluoroquinolones_list.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       routes:

--- a/measure_definitions/fungal.yaml
+++ b/measure_definitions/fungal.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/gabapentinoidsddd.yaml
+++ b/measure_definitions/gabapentinoidsddd.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/glutenfree.yaml
+++ b/measure_definitions/glutenfree.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/highcost_ed.yaml
+++ b/measure_definitions/highcost_ed.yaml
@@ -15,9 +15,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/icsdose.yaml
+++ b/measure_definitions/icsdose.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/injectable_antibiotics.yaml
+++ b/measure_definitions/injectable_antibiotics.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/insulin_detemir.yaml
+++ b/measure_definitions/insulin_detemir.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
     - numerator:
         bnf_codes:

--- a/measure_definitions/ktt13_nsaids_ibuprofen.yaml
+++ b/measure_definitions/ktt13_nsaids_ibuprofen.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:
@@ -28,4 +28,4 @@ queries:
     denominator:
       bnf_codes:
         included:
-          - "100101" # Non-Steroidal Anti-Inflammatory Drugs       
+          - "100101" # Non-Steroidal Anti-Inflammatory Drugs

--- a/measure_definitions/lpaliskiren.yaml
+++ b/measure_definitions/lpaliskiren.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpamiodarone.yaml
+++ b/measure_definitions/lpamiodarone.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpbathshoweremollients.yaml
+++ b/measure_definitions/lpbathshoweremollients.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpcoprox.yaml
+++ b/measure_definitions/lpcoprox.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpdosulepin.yaml
+++ b/measure_definitions/lpdosulepin.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpdronedarone.yaml
+++ b/measure_definitions/lpdronedarone.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpfentanylir.yaml
+++ b/measure_definitions/lpfentanylir.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpglucosamine.yaml
+++ b/measure_definitions/lpglucosamine.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpherbal.yaml
+++ b/measure_definitions/lpherbal.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lphomeopathy.yaml
+++ b/measure_definitions/lphomeopathy.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lplidocaine.yaml
+++ b/measure_definitions/lplidocaine.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpliothyronine.yaml
+++ b/measure_definitions/lpliothyronine.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lplutein.yaml
+++ b/measure_definitions/lplutein.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpminocycline.yaml
+++ b/measure_definitions/lpminocycline.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpneedles.yaml
+++ b/measure_definitions/lpneedles.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpomega3.yaml
+++ b/measure_definitions/lpomega3.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpoxycodone.yaml
+++ b/measure_definitions/lpoxycodone.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpperindopril.yaml
+++ b/measure_definitions/lpperindopril.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lprubefacients.yaml
+++ b/measure_definitions/lprubefacients.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpsilkgarments.yaml
+++ b/measure_definitions/lpsilkgarments.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lptramadolpara.yaml
+++ b/measure_definitions/lptramadolpara.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lptravelvacs.yaml
+++ b/measure_definitions/lptravelvacs.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lptrimipramine.yaml
+++ b/measure_definitions/lptrimipramine.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/lpzomnibus.yaml
+++ b/measure_definitions/lpzomnibus.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/methotrexate.yaml
+++ b/measure_definitions/methotrexate.yaml
@@ -20,26 +20,26 @@ metadata:
   denominator_short: Items for 2.5mg and 10mg methotrexate tablets
   low_is_good: true
   authored_by: caroline.acuda@phc.ox.ac.uk
-  checked_by: 
+  checked_by:
   date_reviewed: 2024-02-12
   next_review: 2026-02-12
   measure_complexity: low
   radar_exclude: false
 
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 
 queries:
   - numerator:
       bnf_codes:
         included:
           # Methotrexate_Tab 10mg
-          - 1001030U0_AC 
+          - 1001030U0_AC
     denominator:
       bnf_codes:
         included:
           # Methotrexate_Tab 10mg
-          - 1001030U0_AC 
+          - 1001030U0_AC
           # Methotrexate_Tab 2.5mg
           - 1001030U0_AB

--- a/measure_definitions/morphine_solution_high_quantity.yaml
+++ b/measure_definitions/morphine_solution_high_quantity.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/morphine_solution_list.yaml
+++ b/measure_definitions/morphine_solution_list.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/nhse_bgts.yaml
+++ b/measure_definitions/nhse_bgts.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/nhse_lancets.yaml
+++ b/measure_definitions/nhse_lancets.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/nimodipine.yaml
+++ b/measure_definitions/nimodipine.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: quantity
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: quantity
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/opioidome.yaml
+++ b/measure_definitions/opioidome.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/opioidper1000.yaml
+++ b/measure_definitions/opioidper1000.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/opioidper1000_120plus.yaml
+++ b/measure_definitions/opioidper1000_120plus.yaml
@@ -10,9 +10,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/opioidspercent.yaml
+++ b/measure_definitions/opioidspercent.yaml
@@ -14,9 +14,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/opioidspercent_plus120.yaml
+++ b/measure_definitions/opioidspercent_plus120.yaml
@@ -10,9 +10,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/ppidose.yaml
+++ b/measure_definitions/ppidose.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/pregabalinmg.yaml
+++ b/measure_definitions/pregabalinmg.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/probiotics.yaml
+++ b/measure_definitions/probiotics.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/saba.yaml
+++ b/measure_definitions/saba.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/seven_day_prescribing.yaml
+++ b/measure_definitions/seven_day_prescribing.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/silver.yaml
+++ b/measure_definitions/silver.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/solublepara.yaml
+++ b/measure_definitions/solublepara.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:
@@ -33,4 +33,4 @@ queries:
           - "0407010F0_AH" # Co-Codamol_Tab 30mg/500mg (brands and generic)
           - "0407010H0_AA" # Paracet_Cap 500mg (brands and generic)
           - "0407010H0_AM" # Paracet_Tab 500mg (brands and generic)
-          - "0407010H0_AQ" # Paracet_Tab Solb 500mg (brands and generic)  
+          - "0407010H0_AQ" # Paracet_Tab Solb 500mg (brands and generic)

--- a/measure_definitions/statinintensity.yaml
+++ b/measure_definitions/statinintensity.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/sulfadiazine.yaml
+++ b/measure_definitions/sulfadiazine.yaml
@@ -20,9 +20,9 @@ metadata:
   next_review: 2026-02-12
   measure_complexity: low
   radar_exclude: false
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/tamoxifen.yaml
+++ b/measure_definitions/tamoxifen.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/toothpaste.yaml
+++ b/measure_definitions/toothpaste.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/trimethoprim.yaml
+++ b/measure_definitions/trimethoprim.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/uti_antibiotics_3_day.yaml
+++ b/measure_definitions/uti_antibiotics_3_day.yaml
@@ -13,9 +13,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: custom
-  denominator: custom
+options:
+  type: prescribing_vs_prescribing
+  output_value: custom
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/vitamind.yaml
+++ b/measure_definitions/vitamind.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       ingredient_ids:

--- a/measure_definitions/vitb.yaml
+++ b/measure_definitions/vitb.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/vitbper1000.yaml
+++ b/measure_definitions/vitbper1000.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/xlpdoxazosin.yaml
+++ b/measure_definitions/xlpdoxazosin.yaml
@@ -12,9 +12,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: cost
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: cost
 queries:
   - numerator:
       bnf_codes:

--- a/measure_definitions/zuclopenthixol.yaml
+++ b/measure_definitions/zuclopenthixol.yaml
@@ -11,9 +11,9 @@ metadata:
   checked_by: n/a
   date_reviewed: n/a
   date_next_review: n/a
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       bnf_codes:

--- a/openprescribing/data/analysis.py
+++ b/openprescribing/data/analysis.py
@@ -81,16 +81,16 @@ class Analysis:
         )
 
     def to_dict(self):
-        analysis_dict = {"output": {}, "queries": []}
+        analysis_dict = {"options": {}, "queries": []}
 
         analysis_dict["queries"].append({"numerator": self.ntr_query.to_dict()})
-        analysis_dict["output"]["numerator"] = "items"
+        analysis_dict["options"]["output_value"] = "items"
 
         if isinstance(self.dtr_query, ListSizeQuery):
-            analysis_dict["output"]["denominator"] = "list_size"
+            analysis_dict["options"]["type"] = "prescribing_vs_list_size"
         else:
             analysis_dict["queries"][0]["denominator"] = self.dtr_query.to_dict()
-            analysis_dict["output"]["denominator"] = "items"
+            analysis_dict["options"]["type"] = "prescribing_vs_prescribing"
 
         if self.org_id:
             analysis_dict["org_id"] = self.org_id

--- a/openprescribing/data/measures/validation.py
+++ b/openprescribing/data/measures/validation.py
@@ -59,19 +59,23 @@ class Query(BaseModel):
     denominator: BNFQuery | None = None
 
 
-output_types = (
+output_values = (
     Literal["items"] | Literal["quantity"] | Literal["cost"] | Literal["custom"]
 )
 
+analysis_types = (
+    Literal["prescribing_vs_prescribing"] | Literal["prescribing_vs_list_size"]
+)
 
-class Output(BaseModel):
-    numerator: output_types
-    denominator: output_types | Literal["list_size"]
+
+class Options(BaseModel):
+    type: analysis_types
+    output_value: output_values
 
 
 class Measure(BaseModel):
     metadata: Metadata
-    output: Output
+    options: Options
     queries: list[Query]
 
     @field_validator("queries")
@@ -131,8 +135,11 @@ def schema():
             Optional("form_routes"): Seq(Str()),
         }
     )
-    # Currently this must be `items`, `quantity`, `cost`, `custom` or `list_size`
-    output = Str()
+    # Currently this must be `items`, `quantity`, `cost`, or `custom`.
+    output_values = Str()
+    # Currently this must be `prescribing_vs_prescribing` or `prescribing_vs_list_size`
+    analysis_types = Str()
+
     query = Map(
         {
             NUMERATOR_KEY: query_params,
@@ -142,7 +149,7 @@ def schema():
     schema = Map(
         {
             "metadata": metadata,
-            "output": Map({NUMERATOR_KEY: output, DENOMINATOR_KEY: output}),
+            "options": Map({"type": analysis_types, "output_value": output_values}),
             "queries": Seq(query),
         }
     )

--- a/tests/data/measures/fixtures/demo-branded-ratio.yaml
+++ b/tests/data/measures/fixtures/demo-branded-ratio.yaml
@@ -3,9 +3,9 @@ metadata:
   tags:
     - demo
   why_it_matters: This one doesn't really matter!
-output:
-  numerator: items
-  denominator: items
+options:
+  type: prescribing_vs_prescribing
+  output_value: items
 queries:
   - numerator:
       product_type: branded

--- a/tests/data/measures/fixtures/invalid-measure-form_routes-and-routes.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-form_routes-and-routes.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure with an invalid combination of form_routes & routes
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       form_routes:

--- a/tests/data/measures/fixtures/invalid-measure-form_routes.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-form_routes.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure which filters by form
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       form_routes:

--- a/tests/data/measures/fixtures/invalid-measure-multiple-queries.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-multiple-queries.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure which filters by form
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   # multiple valid queries
   - numerator:

--- a/tests/data/measures/fixtures/invalid-measure-output.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-output.yaml
@@ -3,9 +3,10 @@ metadata:
   why_it_matters: This is a demo measure which filters by form
   tags:
     - demo
-output:
-  # invalid numerator type
-  numerator: bnf_items
+options:
+  type: prescribing_vs_list_size
+  # invalid output_value type
+  output_value: bnf_items
   denominator: list_size
 queries:
   - numerator:

--- a/tests/data/measures/fixtures/invalid-measure-product-type.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-product-type.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: Invalid product_type
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       product_type: neither_generic_nor_branded

--- a/tests/data/measures/fixtures/invalid-measure-queries.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-queries.yaml
@@ -3,9 +3,9 @@ metadata:
   why_it_matters: This is a demo measure which filters by form
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 # queries is malformed
 queries:
   - numerator:

--- a/tests/data/measures/fixtures/valid-measure.yaml
+++ b/tests/data/measures/fixtures/valid-measure.yaml
@@ -3,9 +3,9 @@
     why_it_matters: This is a demo measure which uses all BNFQuery params correctly
     tags:
       - demo
-  output:
-    numerator: items
-    denominator: list_size
+  options:
+    type: prescribing_vs_list_size
+    output_value: items
   queries:
     - numerator:
         product_type: generic

--- a/tests/data/measures/test_measures.py
+++ b/tests/data/measures/test_measures.py
@@ -17,9 +17,9 @@ def test_load_measure(settings):
             "title": "DEMO Ratio of branded prescribing of a drug to all prescribing of a drug",
             "why_it_matters": "This one doesn't really matter!",
         },
-        "output": {
-            "denominator": "items",
-            "numerator": "items",
+        "options": {
+            "type": "prescribing_vs_prescribing",
+            "output_value": "items",
         },
         "queries": [
             {

--- a/tests/data/test_analysis.py
+++ b/tests/data/test_analysis.py
@@ -105,7 +105,10 @@ def test_to_params_dtr_list_size():
 @pytest.mark.django_db(databases=["data"])
 def test_from_dict():
     analysis_dict = {
-        "output": {"numerator": "items", "denominator": "items"},
+        "options": {
+            "type": "prescribing_vs_prescribing",
+            "output_value": "items",
+        },
         "queries": [
             {
                 "numerator": {
@@ -130,7 +133,10 @@ def test_from_dict():
 @pytest.mark.django_db(databases=["data"])
 def test_from_dict_branded():
     analysis_dict = {
-        "output": {"numerator": "items", "denominator": "items"},
+        "options": {
+            "type": "prescribing_vs_prescribing",
+            "output_value": "items",
+        },
         "queries": [
             {
                 "numerator": {
@@ -156,7 +162,10 @@ def test_from_dict_branded():
 @pytest.mark.django_db(databases=["data"])
 def test_from_dict_numerator_only():
     analysis_dict = {
-        "output": {"numerator": "items", "denominator": "list_size"},
+        "options": {
+            "type": "prescribing_vs_list_size",
+            "output_value": "items",
+        },
         "queries": [
             {
                 "numerator": {
@@ -176,7 +185,10 @@ def test_from_dict_numerator_only():
 @pytest.mark.django_db(databases=["data"])
 def test_from_dict_ingredients():
     analysis_dict = {
-        "output": {"numerator": "items", "denominator": "list_size"},
+        "options": {
+            "type": "prescribing_vs_list_size",
+            "output_value": "items",
+        },
         "queries": [
             {
                 "numerator": {

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -133,9 +133,9 @@ metadata:
   why_it_matters: This is a demo measure
   tags:
     - demo
-output:
-  numerator: items
-  denominator: list_size
+options:
+  type: prescribing_vs_list_size
+  output_value: items
 queries:
   - numerator:
       bnf_codes:
@@ -155,7 +155,10 @@ queries:
 
 def test_analysis_download(client, sample_data, tmp_path, settings):
     analysis_dict = {
-        "output": {"numerator": "items", "denominator": "list_size"},
+        "options": {
+            "type": "prescribing_vs_list_size",
+            "output_value": "items",
+        },
         "queries": [
             {
                 "numerator": {


### PR DESCRIPTION
* instead of specifying the types of the numerator & denominator, specify the type of
  analysis & the output value
* in general, we think that it is the case that measures should only compare a value to
  the same value or to list_size (the number of patients)
* I currently believe there are five v1 measures which are exceptions to this, however
  * we possibly don't need to keep two of them
  * two more support advanced features which we may not support in this measures formet
  * which leaves only one measure, which we don't understand well
* this PR is pretty much just renaming things
  * we don't currently make much use of these parameters, e.g. we currently use the
    presence or absence of a denominator where we could/should use the new options.type
    parameter
  * however when we start supporting more output types (e.g. cost) we will need to make
    more use of this
* update all existing measures (including stubs)
* fixes #388 