### PR TITLE
Flatten the bnf_codes parameter in BNFQuery.to_dict

### DIFF
--- a/measure_definitions/aafpercent.yaml
+++ b/measure_definitions/aafpercent.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/all_antibiotics.yaml
+++ b/measure_definitions/all_antibiotics.yaml
@@ -22,9 +22,8 @@ queries:
       routes:
         - "oral"
       bnf_codes:
-        included:
-          - "0501" # Antibacterial drugs
-        excluded:
-          - "050109" # Exclude antituberculosis drugs
-          - "050110" # Exclude antileprotic drugs
-          - "0501130H0" # Exclude methenamine as this is a urinary antiseptic
+        - "0501" # Antibacterial drugs
+      bnf_codes_excluded:
+        - "050109" # Exclude antituberculosis drugs
+        - "050110" # Exclude antileprotic drugs
+        - "0501130H0" # Exclude methenamine as this is a urinary antiseptic

--- a/measure_definitions/amox_500_15_caps.yaml
+++ b/measure_definitions/amox_500_15_caps.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/aware_antibiotics.yaml
+++ b/measure_definitions/aware_antibiotics.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/bdzadq.yaml
+++ b/measure_definitions/bdzadq.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/bdzper1000.yaml
+++ b/measure_definitions/bdzper1000.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/broad_spectrum.yaml
+++ b/measure_definitions/broad_spectrum.yaml
@@ -21,17 +21,15 @@ queries:
       routes:
         - oral
       bnf_codes:
-          included:
-            - "0501013K0" # Co-Amoxiclav
-            - "0501021" # Cephalosporins
-            - "050112" # Quinolones
+        - "0501013K0" # Co-Amoxiclav
+        - "0501021" # Cephalosporins
+        - "050112" # Quinolones
     denominator:
       routes:
         - oral
       bnf_codes:
-          included:
-            - "0501" #Antibacterial drugs
-          excluded:
-            - "050109" # Exclude antituberculosis drugs
-            - "050110" # Exclude antileprotic drugs
-            - "0501130H0" # Exclude methenamine as this is a urinary antiseptic
+        - "0501" #Antibacterial drugs
+      bnf_codes_excluded:
+        - "050109" # Exclude antituberculosis drugs
+        - "050110" # Exclude antileprotic drugs
+        - "0501130H0" # Exclude methenamine as this is a urinary antiseptic

--- a/measure_definitions/broad_spectrum_list.yaml
+++ b/measure_definitions/broad_spectrum_list.yaml
@@ -21,7 +21,6 @@ queries:
       routes:
         - oral
       bnf_codes:
-        included:
-          - "0501013K0" # Co-Amoxiclav
-          - "0501021" # Cephalosporins
-          - "050112" # Quinolones
+        - "0501013K0" # Co-Amoxiclav
+        - "0501021" # Cephalosporins
+        - "050112" # Quinolones

--- a/measure_definitions/carbon_salbutamol.yaml
+++ b/measure_definitions/carbon_salbutamol.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/cgm_sensors.yaml
+++ b/measure_definitions/cgm_sensors.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/ciclosporin.yaml
+++ b/measure_definitions/ciclosporin.yaml
@@ -18,11 +18,9 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "0802020G0AA" # Ciclosporin (Systemic) (generic)
-          - "0802020T0AA" # Tacrolimus (Systemic) (generic)
+        - "0802020G0AA" # Ciclosporin (Systemic) (generic)
+        - "0802020T0AA" # Tacrolimus (Systemic) (generic)
     denominator:
       bnf_codes:
-        included:
-          - "0802020G0" # Ciclosporin (Systemic) (brand and generic)
-          - "0802020T0" # Tacrolimus (Systemic) (brand and generic)
+        - "0802020G0" # Ciclosporin (Systemic) (brand and generic)
+        - "0802020T0" # Tacrolimus (Systemic) (brand and generic)

--- a/measure_definitions/cmpaperpt.yaml
+++ b/measure_definitions/cmpaperpt.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/dapagliflozin.yaml
+++ b/measure_definitions/dapagliflozin.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/demo-branded-ratio.yaml
+++ b/measure_definitions/demo-branded-ratio.yaml
@@ -10,10 +10,8 @@ queries:
   - numerator:
       product_type: branded
       bnf_codes:
-          included:
-              - 0302000K0
+        - 0302000K0
     denominator:
       product_type: all
       bnf_codes:
-          included:
-              - 0302000K0
+        - 0302000K0

--- a/measure_definitions/demo-penicillin-capsules.yaml
+++ b/measure_definitions/demo-penicillin-capsules.yaml
@@ -11,5 +11,4 @@ queries:
       forms:
         - capsule
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/measure_definitions/demo-penicillin-oral.yaml
+++ b/measure_definitions/demo-penicillin-oral.yaml
@@ -11,5 +11,4 @@ queries:
       routes:
         - oral
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/measure_definitions/demo-penicillin-tablet-oral-2.yaml
+++ b/measure_definitions/demo-penicillin-tablet-oral-2.yaml
@@ -14,5 +14,4 @@ queries:
       routes:
         - oral
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/measure_definitions/demo-penicillin-tablet-oral.yaml
+++ b/measure_definitions/demo-penicillin-tablet-oral.yaml
@@ -11,5 +11,4 @@ queries:
       form_routes:
         - tablet.oral
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/measure_definitions/demo-penicillin-tablet.yaml
+++ b/measure_definitions/demo-penicillin-tablet.yaml
@@ -11,5 +11,4 @@ queries:
       forms:
         - tablet
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/measure_definitions/diltiazem.yaml
+++ b/measure_definitions/diltiazem.yaml
@@ -19,15 +19,13 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "0206020C0AA" # Diltiazem (generic)
-        excluded:
-          - "00206020C0AAAAAA" # Diltiazem 60mg modified-release tablets
-          - "00206020C0AAAJAJ" # Diltiazem 60mg modified-release capsules
+        - "0206020C0AA" # Diltiazem (generic)
+      bnf_codes_excluded:
+        - "00206020C0AAAAAA" # Diltiazem 60mg modified-release tablets
+        - "00206020C0AAAJAJ" # Diltiazem 60mg modified-release capsules
     denominator:
       bnf_codes:
-        included:
-          - "0206020C0" # Diltiazem (brand and generic)
-        excluded:
-          - "0206020C0%AA" # Diltiazem 60mg modified-release tablets (brand and generic)
-          - "0206020C0%AJ" # Diltiazem 60mg modified-release capsules (brand and generic)
+        - "0206020C0" # Diltiazem (brand and generic)
+      bnf_codes_excluded:
+        - "0206020C0%AA" # Diltiazem 60mg modified-release tablets (brand and generic)
+        - "0206020C0%AJ" # Diltiazem 60mg modified-release capsules (brand and generic)

--- a/measure_definitions/doacs_nhse.yaml
+++ b/measure_definitions/doacs_nhse.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/doxy_100_6_qty.yaml
+++ b/measure_definitions/doxy_100_6_qty.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/environmental_inhalers.yaml
+++ b/measure_definitions/environmental_inhalers.yaml
@@ -22,17 +22,15 @@ queries:
       form_routes:
         - "pressurizedinhalation.inhalation"
       bnf_codes:
-        included:
-          - "03" # BNF Chapter 3
-        excluded:
-          - "0301011R0" # Exclude salbutamol
+        - "03" # BNF Chapter 3
+      bnf_codes_excluded:
+        - "0301011R0" # Exclude salbutamol
     denominator:
       form_routes:
         - "pressurizedinhalation.inhalation"
         - "powderinhalation.inhalation"
         - "inhalationsolution.inhalation"
       bnf_codes:
-        included:
-          - "03" # BNF Chapter 3
-        excluded:
-          - "0301011R0" # Exclude salbutamol
+        - "03" # BNF Chapter 3
+      bnf_codes_excluded:
+        - "0301011R0" # Exclude salbutamol

--- a/measure_definitions/excess_pens.yaml
+++ b/measure_definitions/excess_pens.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/fluoroquinolones_list.yaml
+++ b/measure_definitions/fluoroquinolones_list.yaml
@@ -23,5 +23,4 @@ queries:
         - intravenous
         - inhalation
       bnf_codes:
-        included:
-          - "050112" # Quinolones
+        - "050112" # Quinolones

--- a/measure_definitions/fungal.yaml
+++ b/measure_definitions/fungal.yaml
@@ -18,6 +18,5 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "1310020A0" # Amorolfine Hydrochloride
-          - "1310020T0_AA" # Tioconazole_Medic Nail Lacquer 283mg/ml (branded and generic)
+        - "1310020A0" # Amorolfine Hydrochloride
+        - "1310020T0_AA" # Tioconazole_Medic Nail Lacquer 283mg/ml (branded and generic)

--- a/measure_definitions/gabapentinoidsddd.yaml
+++ b/measure_definitions/gabapentinoidsddd.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/glutenfree.yaml
+++ b/measure_definitions/glutenfree.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/highcost_ed.yaml
+++ b/measure_definitions/highcost_ed.yaml
@@ -21,15 +21,14 @@ options:
 queries:
   - numerator:
       bnf_codes:
-          included:
-              - '070405'
-          excluded:
-              - 0704050Z0AAABAB
-              - 0704050Z0AAAAAA
-              - 0704050Z0AAACAC
-              - 0704050R0AAAAAA
-              - 0704050R0AAABAB
-              - 0704050R0AAADAD
-              - 0704050AAAAABAB
-              - 0704050AAAAACAC
-              - 0704050AAAAAAAA
+        - '070405'
+      bnf_codes_excluded:
+        - 0704050Z0AAABAB
+        - 0704050Z0AAAAAA
+        - 0704050Z0AAACAC
+        - 0704050R0AAAAAA
+        - 0704050R0AAABAB
+        - 0704050R0AAADAD
+        - 0704050AAAAABAB
+        - 0704050AAAAACAC
+        - 0704050AAAAAAAA

--- a/measure_definitions/icsdose.yaml
+++ b/measure_definitions/icsdose.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/injectable_antibiotics.yaml
+++ b/measure_definitions/injectable_antibiotics.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/insulin_detemir.yaml
+++ b/measure_definitions/insulin_detemir.yaml
@@ -20,6 +20,5 @@ options:
 queries:
     - numerator:
         bnf_codes:
-            included:
-                # Insulin detemir
-                - 0601012X0
+          # Insulin detemir
+          - 0601012X0

--- a/measure_definitions/ktt13_nsaids_ibuprofen.yaml
+++ b/measure_definitions/ktt13_nsaids_ibuprofen.yaml
@@ -20,12 +20,10 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "100101" # Non-Steroidal Anti-Inflammatory Drugs
-        excluded:
-          - "1001010J0" # Ibuprofen
-          - "1001010P0" # Naproxen
+        - "100101" # Non-Steroidal Anti-Inflammatory Drugs
+      bnf_codes_excluded:
+        - "1001010J0" # Ibuprofen
+        - "1001010P0" # Naproxen
     denominator:
       bnf_codes:
-        included:
-          - "100101" # Non-Steroidal Anti-Inflammatory Drugs
+        - "100101" # Non-Steroidal Anti-Inflammatory Drugs

--- a/measure_definitions/lpaliskiren.yaml
+++ b/measure_definitions/lpaliskiren.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpamiodarone.yaml
+++ b/measure_definitions/lpamiodarone.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpbathshoweremollients.yaml
+++ b/measure_definitions/lpbathshoweremollients.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpcoprox.yaml
+++ b/measure_definitions/lpcoprox.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpdosulepin.yaml
+++ b/measure_definitions/lpdosulepin.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpdronedarone.yaml
+++ b/measure_definitions/lpdronedarone.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpfentanylir.yaml
+++ b/measure_definitions/lpfentanylir.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpglucosamine.yaml
+++ b/measure_definitions/lpglucosamine.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpherbal.yaml
+++ b/measure_definitions/lpherbal.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lphomeopathy.yaml
+++ b/measure_definitions/lphomeopathy.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lplidocaine.yaml
+++ b/measure_definitions/lplidocaine.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpliothyronine.yaml
+++ b/measure_definitions/lpliothyronine.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lplutein.yaml
+++ b/measure_definitions/lplutein.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpminocycline.yaml
+++ b/measure_definitions/lpminocycline.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpneedles.yaml
+++ b/measure_definitions/lpneedles.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpomega3.yaml
+++ b/measure_definitions/lpomega3.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpoxycodone.yaml
+++ b/measure_definitions/lpoxycodone.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpperindopril.yaml
+++ b/measure_definitions/lpperindopril.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lprubefacients.yaml
+++ b/measure_definitions/lprubefacients.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpsilkgarments.yaml
+++ b/measure_definitions/lpsilkgarments.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lptramadolpara.yaml
+++ b/measure_definitions/lptramadolpara.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lptravelvacs.yaml
+++ b/measure_definitions/lptravelvacs.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lptrimipramine.yaml
+++ b/measure_definitions/lptrimipramine.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/lpzomnibus.yaml
+++ b/measure_definitions/lpzomnibus.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/methotrexate.yaml
+++ b/measure_definitions/methotrexate.yaml
@@ -33,13 +33,11 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          # Methotrexate_Tab 10mg
-          - 1001030U0_AC
+        # Methotrexate_Tab 10mg
+        - 1001030U0_AC
     denominator:
       bnf_codes:
-        included:
-          # Methotrexate_Tab 10mg
-          - 1001030U0_AC
-          # Methotrexate_Tab 2.5mg
-          - 1001030U0_AB
+        # Methotrexate_Tab 10mg
+        - 1001030U0_AC
+        # Methotrexate_Tab 2.5mg
+        - 1001030U0_AB

--- a/measure_definitions/morphine_solution_high_quantity.yaml
+++ b/measure_definitions/morphine_solution_high_quantity.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/morphine_solution_list.yaml
+++ b/measure_definitions/morphine_solution_list.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/nhse_bgts.yaml
+++ b/measure_definitions/nhse_bgts.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/nhse_lancets.yaml
+++ b/measure_definitions/nhse_lancets.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/nimodipine.yaml
+++ b/measure_definitions/nimodipine.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/opioidome.yaml
+++ b/measure_definitions/opioidome.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/opioidper1000.yaml
+++ b/measure_definitions/opioidper1000.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/opioidper1000_120plus.yaml
+++ b/measure_definitions/opioidper1000_120plus.yaml
@@ -16,5 +16,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/opioidspercent.yaml
+++ b/measure_definitions/opioidspercent.yaml
@@ -20,5 +20,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/opioidspercent_plus120.yaml
+++ b/measure_definitions/opioidspercent_plus120.yaml
@@ -16,5 +16,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/ppidose.yaml
+++ b/measure_definitions/ppidose.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/pregabalinmg.yaml
+++ b/measure_definitions/pregabalinmg.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/probiotics.yaml
+++ b/measure_definitions/probiotics.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/saba.yaml
+++ b/measure_definitions/saba.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/seven_day_prescribing.yaml
+++ b/measure_definitions/seven_day_prescribing.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/silver.yaml
+++ b/measure_definitions/silver.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/solublepara.yaml
+++ b/measure_definitions/solublepara.yaml
@@ -18,19 +18,17 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "0407010F0_AC" # Co-Codamol Eff_Tab 8mg/500mg (brands and generic)
-          - "0407010F0_AF" # Co-Codamol Eff_Tab 30mg/500mg (brands and generic)
-          - "0407010H0_AQ" # Paracet_Tab Solb 500mg (brands and generic)
+        - "0407010F0_AC" # Co-Codamol Eff_Tab 8mg/500mg (brands and generic)
+        - "0407010F0_AF" # Co-Codamol Eff_Tab 30mg/500mg (brands and generic)
+        - "0407010H0_AQ" # Paracet_Tab Solb 500mg (brands and generic)
     denominator:
       bnf_codes:
-        included:
-          - "0407010F0_AA" # Co-Codamol_Tab 8mg/500mg (brands and generic)
-          - "0407010F0_AB" # Co-Codamol_Cap 8mg/500mg (brands and generic)
-          - "0407010F0_AC" # Co-Codamol Eff_Tab 8mg/500mg (brands and generic)
-          - "0407010F0_AD" # Co-Codamol_Cap 30mg/500mg (brands and generic)
-          - "0407010F0_AF" # Co-Codamol Eff_Tab 30mg/500mg (brands and generic)
-          - "0407010F0_AH" # Co-Codamol_Tab 30mg/500mg (brands and generic)
-          - "0407010H0_AA" # Paracet_Cap 500mg (brands and generic)
-          - "0407010H0_AM" # Paracet_Tab 500mg (brands and generic)
-          - "0407010H0_AQ" # Paracet_Tab Solb 500mg (brands and generic)
+        - "0407010F0_AA" # Co-Codamol_Tab 8mg/500mg (brands and generic)
+        - "0407010F0_AB" # Co-Codamol_Cap 8mg/500mg (brands and generic)
+        - "0407010F0_AC" # Co-Codamol Eff_Tab 8mg/500mg (brands and generic)
+        - "0407010F0_AD" # Co-Codamol_Cap 30mg/500mg (brands and generic)
+        - "0407010F0_AF" # Co-Codamol Eff_Tab 30mg/500mg (brands and generic)
+        - "0407010F0_AH" # Co-Codamol_Tab 30mg/500mg (brands and generic)
+        - "0407010H0_AA" # Paracet_Cap 500mg (brands and generic)
+        - "0407010H0_AM" # Paracet_Tab 500mg (brands and generic)
+        - "0407010H0_AQ" # Paracet_Tab Solb 500mg (brands and generic)

--- a/measure_definitions/statinintensity.yaml
+++ b/measure_definitions/statinintensity.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/sulfadiazine.yaml
+++ b/measure_definitions/sulfadiazine.yaml
@@ -26,5 +26,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-          included:
-              - 0501080J0AAABAB #sulfadiazine
+        - 0501080J0AAABAB #sulfadiazine

--- a/measure_definitions/tamoxifen.yaml
+++ b/measure_definitions/tamoxifen.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/toothpaste.yaml
+++ b/measure_definitions/toothpaste.yaml
@@ -17,5 +17,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/trimethoprim.yaml
+++ b/measure_definitions/trimethoprim.yaml
@@ -17,10 +17,8 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "0501080W0" # Trimethoprim
+        - "0501080W0" # Trimethoprim
     denominator:
       bnf_codes:
-        included:
-          - "0501080W0" # Trimethoprim
-          - "0501130R0" # Nitrofurantoin
+        - "0501080W0" # Trimethoprim
+        - "0501130R0" # Nitrofurantoin

--- a/measure_definitions/uti_antibiotics_3_day.yaml
+++ b/measure_definitions/uti_antibiotics_3_day.yaml
@@ -19,5 +19,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/vitb.yaml
+++ b/measure_definitions/vitb.yaml
@@ -18,13 +18,11 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "0906027G0_AA" # Vit B Co_Tab
-          - "0906027G0_AB" # Vit B Co_Str_Tab
+        - "0906027G0_AA" # Vit B Co_Tab
+        - "0906027G0_AB" # Vit B Co_Str_Tab
     denominator:
       bnf_codes:
-        included:
-          - "0906027G0_AA" # Vit B Co_Tab
-          - "0906027G0_AB" # Vit B Co_Str_Tab
-          - "0906026M0_AF" # Thiamine HCL_Tab 50mg
-          - "0906026M0_AG" # Thiamine HCL_Tab 100mg
+        - "0906027G0_AA" # Vit B Co_Tab
+        - "0906027G0_AB" # Vit B Co_Str_Tab
+        - "0906026M0_AF" # Thiamine HCL_Tab 50mg
+        - "0906026M0_AG" # Thiamine HCL_Tab 100mg

--- a/measure_definitions/vitbper1000.yaml
+++ b/measure_definitions/vitbper1000.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "0906027G0" # Vit B Compound
+        - "0906027G0" # Vit B Compound

--- a/measure_definitions/xlpdoxazosin.yaml
+++ b/measure_definitions/xlpdoxazosin.yaml
@@ -18,5 +18,4 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - ""
+        - ""

--- a/measure_definitions/zuclopenthixol.yaml
+++ b/measure_definitions/zuclopenthixol.yaml
@@ -17,10 +17,8 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "040201010" # Zuclopenthixol Acetate
+        - "040201010" # Zuclopenthixol Acetate
     denominator:
       bnf_codes:
-        included:
-          - "040201010" # acetate
-          - "0402020Z0" # decanoate
+        - "040201010" # acetate
+        - "0402020Z0" # decanoate

--- a/openprescribing/data/bnf_query.py
+++ b/openprescribing/data/bnf_query.py
@@ -168,7 +168,8 @@ class BNFQuery:
 
     @classmethod
     def from_dict(cls, query_dict):
-        bnf_codes_dict = query_dict.get("bnf_codes", {"included": [], "excluded": []})
+        bnf_codes = tuple(query_dict.get("bnf_codes", []))
+        bnf_codes_excluded = tuple(query_dict.get("bnf_codes_excluded", []))
         product_type = query_dict.get("product_type", cls.PRODUCT_TYPE_DEFAULT)
 
         form_routes = tuple(query_dict.get("form_routes", []))
@@ -185,9 +186,9 @@ class BNFQuery:
         vtm_ids_excluded = tuple(query_dict.get("vtm_ids_excluded", []))
 
         return cls(
-            tuple(bnf_codes_dict["included"]),
-            tuple(bnf_codes_dict.get("excluded", [])),
-            ProductType(product_type),
+            bnf_codes=bnf_codes,
+            bnf_codes_excluded=bnf_codes_excluded,
+            product_type=ProductType(product_type),
             form_routes=form_routes,
             form_routes_excluded=form_routes_excluded,
             forms=forms,
@@ -201,11 +202,11 @@ class BNFQuery:
         )
 
     def to_dict(self):
-        bnf_query_dict = {
-            "bnf_codes": {"included": list(self.bnf_codes)},
-        }
+        bnf_query_dict = {}
+        if self.bnf_codes:
+            bnf_query_dict["bnf_codes"] = list(self.bnf_codes)
         if self.bnf_codes_excluded:
-            bnf_query_dict["bnf_codes"]["excluded"] = list(self.bnf_codes_excluded)
+            bnf_query_dict["bnf_codes_excluded"] = list(self.bnf_codes_excluded)
         if not self.product_type == ProductType.ALL:
             bnf_query_dict["product_type"] = self.product_type.value
         if self.form_routes:

--- a/openprescribing/data/measures/validation.py
+++ b/openprescribing/data/measures/validation.py
@@ -31,13 +31,9 @@ class Metadata(BaseModel):
     why_it_matters: str
 
 
-class BNFCode(BaseModel):
-    included: list[str]
-    excluded: list[str] | None = None
-
-
 class BNFQuery(BaseModel):
-    bnf_codes: BNFCode | None = None
+    bnf_codes: list[str] | None = None
+    bnf_codes_excluded: list[str] | None = None
     form_routes: list[str] | None = None
     forms: list[str] | None = None
     routes: list[str] | None = None
@@ -113,16 +109,11 @@ def schema():
     # nb. schema does not validate this is a valid BNF code
     bnf_code = Str()
     bnf_code_list = Seq(bnf_code)
-    bnf_codes = Map(
-        {
-            Optional("included"): bnf_code_list,
-            Optional("excluded"): bnf_code_list,
-        }
-    )
     # all of these query params are ANDed together
     query_params = Map(
         {
-            Optional("bnf_codes"): bnf_codes,
+            Optional("bnf_codes"): bnf_code_list,
+            Optional("bnf_codes_excluded"): bnf_code_list,
             # corresponds to `cd` in `Ing`
             Optional("ingredient_ids"): Seq(Int()),
             # from a set list like `tablet`

--- a/tests/data/measures/fixtures/demo-branded-ratio.yaml
+++ b/tests/data/measures/fixtures/demo-branded-ratio.yaml
@@ -10,10 +10,8 @@ queries:
   - numerator:
       product_type: branded
       bnf_codes:
-          included:
-              - 0302000K0
+        - 0302000K0
     denominator:
       product_type: all
       bnf_codes:
-          included:
-              - 0302000K0
+        - 0302000K0

--- a/tests/data/measures/fixtures/invalid-measure-form_routes-and-routes.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-form_routes-and-routes.yaml
@@ -14,5 +14,4 @@ queries:
       routes:
         - nasal
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/tests/data/measures/fixtures/invalid-measure-form_routes.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-form_routes.yaml
@@ -11,5 +11,4 @@ queries:
       form_routes:
         - unicorn.interstellar
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/tests/data/measures/fixtures/invalid-measure-multiple-queries.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-multiple-queries.yaml
@@ -12,11 +12,9 @@ queries:
       forms:
         - tablet
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"
   - numerator:
       forms:
         - tablet
       bnf_codes:
-          included:
-              - "0501014"
+        - "0501014"

--- a/tests/data/measures/fixtures/invalid-measure-output.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-output.yaml
@@ -13,5 +13,4 @@ queries:
       forms:
         - tablet
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/tests/data/measures/fixtures/invalid-measure-product-type.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-product-type.yaml
@@ -10,5 +10,4 @@ queries:
   - numerator:
       product_type: neither_generic_nor_branded
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/tests/data/measures/fixtures/invalid-measure-queries.yaml
+++ b/tests/data/measures/fixtures/invalid-measure-queries.yaml
@@ -12,9 +12,7 @@ queries:
       forms:
         - tablet
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"
   - denominator:
       bnf_codes:
-          included:
-              - "0501013"
+        - "0501013"

--- a/tests/data/measures/fixtures/valid-measure.yaml
+++ b/tests/data/measures/fixtures/valid-measure.yaml
@@ -12,5 +12,4 @@
         form_routes:
           - tablet.oral
         bnf_codes:
-            included:
-                - "0501013"
+          - "0501013"

--- a/tests/data/measures/test_measures.py
+++ b/tests/data/measures/test_measures.py
@@ -24,19 +24,15 @@ def test_load_measure(settings):
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": [
-                            "0302000K0",
-                        ],
-                    },
+                    "bnf_codes": [
+                        "0302000K0",
+                    ],
                     "product_type": "branded",
                 },
                 "denominator": {
-                    "bnf_codes": {
-                        "included": [
-                            "0302000K0",
-                        ],
-                    },
+                    "bnf_codes": [
+                        "0302000K0",
+                    ],
                     "product_type": "all",
                 },
             },

--- a/tests/data/test_analysis.py
+++ b/tests/data/test_analysis.py
@@ -112,15 +112,11 @@ def test_from_dict():
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["01"],
-                        "excluded": ["0101"],
-                    },
+                    "bnf_codes": ["01"],
+                    "bnf_codes_excluded": ["0101"],
                 },
                 "denominator": {
-                    "bnf_codes": {
-                        "included": ["01"],
-                    }
+                    "bnf_codes": ["01"],
                 },
             }
         ],
@@ -141,16 +137,12 @@ def test_from_dict_branded():
             {
                 "numerator": {
                     "product_type": "branded",
-                    "bnf_codes": {
-                        "included": ["01"],
-                        "excluded": ["0101"],
-                    },
+                    "bnf_codes": ["01"],
+                    "bnf_codes_excluded": ["0101"],
                 },
                 "denominator": {
                     "product_type": "branded",
-                    "bnf_codes": {
-                        "included": ["01"],
-                    },
+                    "bnf_codes": ["01"],
                 },
             }
         ],
@@ -170,10 +162,8 @@ def test_from_dict_numerator_only():
             {
                 "numerator": {
                     "product_type": "branded",
-                    "bnf_codes": {
-                        "included": ["01"],
-                        "excluded": ["0101"],
-                    },
+                    "bnf_codes": ["01"],
+                    "bnf_codes_excluded": ["0101"],
                 }
             }
         ],
@@ -192,9 +182,7 @@ def test_from_dict_ingredients():
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["01"],
-                    },
+                    "bnf_codes": ["01"],
                     "ingredient_ids": [1],
                 },
             }

--- a/tests/data/test_bnf_query.py
+++ b/tests/data/test_bnf_query.py
@@ -710,36 +710,33 @@ def test_to_params_with_ingredient_ids():
 
 def test_to_dict_bnf_codes_included():
     query = BNFQuery(bnf_codes=["1001030U0"])
-    assert query.to_dict() == {"bnf_codes": {"included": ["1001030U0"]}}
+    assert query.to_dict() == {"bnf_codes": ["1001030U0"]}
 
 
 def test_to_dict_bnf_codes_excluded():
     query = BNFQuery(bnf_codes=["1001030U0"], bnf_codes_excluded=["1001030U0AAABAB"])
     assert query.to_dict() == {
-        "bnf_codes": {
-            "included": ["1001030U0"],
-            "excluded": ["1001030U0AAABAB"],
-        }
+        "bnf_codes": ["1001030U0"],
+        "bnf_codes_excluded": ["1001030U0AAABAB"],
     }
 
 
 def test_to_dict_product_type():
     query = BNFQuery(bnf_codes=["1001030U0"], product_type=ProductType.GENERIC)
     assert query.to_dict() == {
-        "bnf_codes": {"included": ["1001030U0"]},
+        "bnf_codes": ["1001030U0"],
         "product_type": "generic",
     }
 
 
 def test_to_dict_product_type_all_omitted():
     query = BNFQuery(bnf_codes=["1001030U0"], product_type=ProductType.ALL)
-    assert query.to_dict() == {"bnf_codes": {"included": ["1001030U0"]}}
+    assert query.to_dict() == {"bnf_codes": ["1001030U0"]}
 
 
 def test_to_dict_form_routes():
     query = BNFQuery(form_routes=["tablet.oral"])
     assert query.to_dict() == {
-        "bnf_codes": {"included": []},
         "form_routes": ["tablet.oral"],
     }
 
@@ -747,7 +744,6 @@ def test_to_dict_form_routes():
 def test_to_dict_form_routes_excluded():
     query = BNFQuery(form_routes_excluded=["solutioninjection.intravenous"])
     assert query.to_dict() == {
-        "bnf_codes": {"included": []},
         "form_routes_excluded": ["solutioninjection.intravenous"],
     }
 
@@ -760,7 +756,6 @@ def test_to_dict_forms_and_routes():
         routes_excluded=["intravenous"],
     )
     assert query.to_dict() == {
-        "bnf_codes": {"included": []},
         "forms": ["tablet"],
         "forms_excluded": ["capsule"],
         "routes": ["oral"],
@@ -771,7 +766,6 @@ def test_to_dict_forms_and_routes():
 def test_to_dict_ingredient_ids():
     query = BNFQuery(ingredient_ids=[53034005])
     assert query.to_dict() == {
-        "bnf_codes": {"included": []},
         "ingredient_ids": [53034005],
     }
 
@@ -779,7 +773,6 @@ def test_to_dict_ingredient_ids():
 def test_to_dict_ingredient_ids_excluded():
     query = BNFQuery(ingredient_ids_excluded=[53034005])
     assert query.to_dict() == {
-        "bnf_codes": {"included": []},
         "ingredient_ids_excluded": [53034005],
     }
 
@@ -787,7 +780,6 @@ def test_to_dict_ingredient_ids_excluded():
 def test_to_dict_vtm_ids():
     query = BNFQuery(vtm_ids=[15219611000001105])
     assert query.to_dict() == {
-        "bnf_codes": {"included": []},
         "vtm_ids": [15219611000001105],
     }
 
@@ -795,19 +787,18 @@ def test_to_dict_vtm_ids():
 def test_to_dict_vtm_ids_excluded():
     query = BNFQuery(vtm_ids_excluded=[108502004])
     assert query.to_dict() == {
-        "bnf_codes": {"included": []},
         "vtm_ids_excluded": [108502004],
     }
 
 
 def test_from_dict_bnf_codes_included():
-    query = BNFQuery.from_dict({"bnf_codes": {"included": ["1001030U0"]}})
+    query = BNFQuery.from_dict({"bnf_codes": ["1001030U0"]})
     assert query == BNFQuery(bnf_codes=["1001030U0"])
 
 
 def test_from_dict_bnf_codes_excluded():
     query = BNFQuery.from_dict(
-        {"bnf_codes": {"included": ["1001030U0"], "excluded": ["1001030U0AAABAB"]}}
+        {"bnf_codes": ["1001030U0"], "bnf_codes_excluded": ["1001030U0AAABAB"]}
     )
     assert query == BNFQuery(
         bnf_codes=["1001030U0"], bnf_codes_excluded=["1001030U0AAABAB"]
@@ -873,9 +864,7 @@ def test_from_dict_vtm_ids_excluded():
 
 def test_from_dict_form_route():
     test_dict = {
-        "bnf_codes": {
-            "included": ["0203020C0AAAAAA"],
-        },
+        "bnf_codes": ["0203020C0AAAAAA"],
         "form_routes": ["solutioninjection.intravenous"],
     }
     query = BNFQuery.from_dict(test_dict)
@@ -884,9 +873,7 @@ def test_from_dict_form_route():
 
 def test_from_dict_form_route_excluded():
     test_dict = {
-        "bnf_codes": {
-            "included": ["0203020C0AAAAAA"],
-        },
+        "bnf_codes": ["0203020C0AAAAAA"],
         "form_routes": ["solutioninjection.intravenous"],
         "form_routes_excluded": ["suspension.oral"],
     }
@@ -897,9 +884,7 @@ def test_from_dict_form_route_excluded():
 def test_from_dict_separate_form_route():
     # forms and routes are preserved as-is, rather than being expanded into form_routes.
     test_dict = {
-        "bnf_codes": {
-            "included": ["0203020C0AAAAAA"],
-        },
+        "bnf_codes": ["0203020C0AAAAAA"],
         "forms": ["solutioninjection"],
         "routes": ["intravenous"],
     }

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -19,9 +19,7 @@ def _analysis_dict_to_param(analysis_dict):
                 "queries": [
                     {
                         "numerator": {
-                            "bnf_codes": {
-                                "included": ["1001030U0"],
-                            },
+                            "bnf_codes": ["1001030U0"],
                         },
                     },
                 ],
@@ -33,9 +31,7 @@ def _analysis_dict_to_param(analysis_dict):
                 "queries": [
                     {
                         "numerator": {
-                            "bnf_codes": {
-                                "included": ["1001030U0"],
-                            },
+                            "bnf_codes": ["1001030U0"],
                         },
                     },
                 ],
@@ -48,10 +44,8 @@ def _analysis_dict_to_param(analysis_dict):
                 "queries": [
                     {
                         "numerator": {
-                            "bnf_codes": {
-                                "included": ["1001030U0"],
-                                "excluded": ["1001030U0AAABAB"],
-                            },
+                            "bnf_codes": ["1001030U0"],
+                            "bnf_codes_excluded": ["1001030U0AAABAB"],
                         },
                     },
                 ],
@@ -63,14 +57,10 @@ def _analysis_dict_to_param(analysis_dict):
                 "queries": [
                     {
                         "numerator": {
-                            "bnf_codes": {
-                                "included": ["1001030U0AA"],
-                            },
+                            "bnf_codes": ["1001030U0AA"],
                         },
                         "denominator": {
-                            "bnf_codes": {
-                                "included": ["1001030U0"],
-                            },
+                            "bnf_codes": ["1001030U0"],
                         },
                     },
                 ],
@@ -93,9 +83,7 @@ def test_prescribing_deciles(client, sample_data):
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["1001030U0"],
-                    },
+                    "bnf_codes": ["1001030U0"],
                 },
             },
         ],
@@ -115,9 +103,7 @@ def test_prescribing_deciles_with_practice(client, sample_data):
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["1001030U0"],
-                    },
+                    "bnf_codes": ["1001030U0"],
                 },
             },
         ],
@@ -138,10 +124,8 @@ def test_prescribing_deciles_with_exclusion(client, sample_data):
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["1001030U0"],
-                        "excluded": ["1001030U0AAABAB"],
-                    },
+                    "bnf_codes": ["1001030U0"],
+                    "bnf_codes_excluded": ["1001030U0AAABAB"],
                 },
             },
         ],
@@ -161,14 +145,10 @@ def test_prescribing_deciles_with_denominator(client, sample_data):
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["1001030U0AA"],
-                    },
+                    "bnf_codes": ["1001030U0AA"],
                 },
                 "denominator": {
-                    "bnf_codes": {
-                        "included": ["1001030U0"],
-                    },
+                    "bnf_codes": ["1001030U0"],
                 },
             },
         ],
@@ -190,9 +170,7 @@ def test_prescribing_medications(client, sample_data):
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["1001030U0"],
-                    },
+                    "bnf_codes": ["1001030U0"],
                 },
             },
         ],
@@ -221,9 +199,7 @@ def test_prescribing_medications_groups_other(client, sample_data, monkeypatch):
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["1001030U0"],
-                    },
+                    "bnf_codes": ["1001030U0"],
                 },
             },
         ],

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -17,7 +17,7 @@ def test_analysis(client, sample_data):
     rsp = client.get("?ntr_bnf_codes=1001030U0")
     assert rsp.status_code == 200
     assert (
-        "numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0"
+        "numerator%22%3A+%7B%22bnf_codes%22%3A+%5B%221001030U0"
         in rsp.context["prescribing_urls"]["deciles"]
     )
     assert rsp.context["analysis_presentation"].chart_type == ChartType.DECILES
@@ -26,14 +26,14 @@ def test_analysis(client, sample_data):
     rsp = client.get("?ntr_bnf_codes=1001030U0&dtr_bnf_codes=1001")
     assert rsp.status_code == 200
     assert (
-        "denominator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001"
+        "denominator%22%3A+%7B%22bnf_codes%22%3A+%5B%221001"
         in rsp.context["prescribing_urls"]["deciles"]
     )
 
     rsp = client.get("?ntr_bnf_codes=1001030U0AAABAB,1001030U0AAABAB")
     assert rsp.status_code == 200
     assert (
-        "numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0AAABAB%22%2C+%221001030U0AAABAB"
+        "numerator%22%3A+%7B%22bnf_codes%22%3A+%5B%221001030U0AAABAB%22%2C+%221001030U0AAABAB"
         in rsp.context["prescribing_urls"]["deciles"]
     )
 
@@ -42,7 +42,7 @@ def test_analysis(client, sample_data):
     )
     assert rsp.status_code == 200
     assert (
-        "numerator%22%3A+%7B%22bnf_codes%22%3A+%7B%22included%22%3A+%5B%221001030U0AA%22%5D%2C+%22excluded%22%3A+%5B%221001030U0AAABAB"
+        "numerator%22%3A+%7B%22bnf_codes%22%3A+%5B%221001030U0AA%22%5D%2C+%22bnf_codes_excluded%22%3A+%5B%221001030U0AAABAB"
         in rsp.context["prescribing_urls"]["deciles"]
     )
 
@@ -143,8 +143,7 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "1001030U0"
+        - "1001030U0"
 
 """
     (tmp_path / "test-measure.yaml").write_text(test_yaml)
@@ -170,12 +169,10 @@ options:
 queries:
   - numerator:
       bnf_codes:
-        included:
-          - "1001030U0"
+        - "1001030U0"
     denominator:
       bnf_codes:
-        included:
-          - "9999999"
+        - "9999999"
 """
     (tmp_path / "test-measure.yaml").write_text(test_yaml)
     settings.MEASURE_DEFINITIONS_PATH = tmp_path
@@ -195,9 +192,7 @@ def test_analysis_download(client, sample_data, tmp_path, settings):
         "queries": [
             {
                 "numerator": {
-                    "bnf_codes": {
-                        "included": ["01"],
-                    },
+                    "bnf_codes": ["01"],
                     "ingredient_ids": [1],
                 },
             }


### PR DESCRIPTION
We go from eg:

    bnf_codes:
        included:
             - 0101
        excluded:
             - 010102

to:

    bnf_codes:
         - 0101
    bnf_codes_excluded:
         - 010102

This now matches how other fields are specified.