### PR TITLE
Don't show unprescribed medications in by-medication chart

### DIFF
--- a/openprescribing/data/queries/get_medication_date_matrix.py
+++ b/openprescribing/data/queries/get_medication_date_matrix.py
@@ -24,8 +24,8 @@ def get_medication_date_matrix(cursor, query, date_count=None):
     The `date_count` argument allows restricting to just the N most recent months of
     prescribing data.
 
-    There is one row for each BNF code matching the query; codes with no prescribing in
-    the date range appear as all-zero rows.
+    There is one row for each BNF code matching the query that has prescribing in the
+    date range; codes with no prescribing in the date range are omitted.
 
     We first build a matrix with one row per presentation (using `presentation_id`
     directly as the row index, just as `get_practice_date_matrix` uses `practice_id`)
@@ -56,15 +56,16 @@ def get_medication_date_matrix(cursor, query, date_count=None):
         col_labels=dates,
     )
 
-    # Collapse presentations into one row per matching BNF code.  Codes with no
-    # presentations get an empty group (and so an all-zero row).
+    # Collapse presentations into one row per matching BNF code.
     code_to_ids = get_bnf_code_to_presentation_ids(cursor)
     row_label_map = tuple(
         (code, code_to_ids.get(code, ()))
         for code in query.get_matching_presentation_codes()
     )
+    grouped = presentation_date_matrix.group_rows(row_label_map)
 
-    return presentation_date_matrix.group_rows(row_label_map)
+    # Drop codes with no prescribing in the date range.
+    return grouped.drop_zero_rows()
 
 
 @functools.cache

--- a/openprescribing/data/rxdb/labelled_matrix.py
+++ b/openprescribing/data/rxdb/labelled_matrix.py
@@ -114,6 +114,16 @@ class LabelledMatrix:
         values = np.nanpercentile(self.values, centiles, axis=0)
         return LabelledMatrix(values, centiles, self.col_labels)
 
+    def drop_zero_rows(self):
+        """Return a new LabelledMatrix with all-zero rows removed."""
+
+        keep = np.any(self.values != 0, axis=1)
+        return self.__class__(
+            self.values[keep],
+            tuple(label for label, keep_row in zip(self.row_labels, keep) if keep_row),
+            self.col_labels,
+        )
+
 
 # These "row groupers" are pure functions of their inputs, are not entirely trivial to
 # construct, and are expected to be used repeatedly, so it makes sense to cache them

--- a/tests/data/queries/test_get_medication_date_matrix.py
+++ b/tests/data/queries/test_get_medication_date_matrix.py
@@ -11,11 +11,11 @@ from .alternative_implementations import get_medication_date_matrix_alternative
 def test_get_medication_date_matrix_spot_check(rxdb):
     BNFCode.objects.create(code="1001030U0AAABAB", level=7)
     BNFCode.objects.create(code="1001030U0AAACAC", level=7)
-    # Matches the query prefix but is only prescribed outside the date window, so it
-    # appears as an all-zero row.
+    # Matches the query prefix but is only prescribed outside the date window, so is
+    # not included in result.
     BNFCode.objects.create(code="1001030U0AAADAD", level=7)
-    # Matches the query prefix but is never prescribed at all, so it also appears as an
-    # all-zero row.
+    # Matches the query prefix but is never prescribed at all, so is not included in
+    # result.
     BNFCode.objects.create(code="1001030U0AAAEAE", level=7)
     rxdb.ingest(
         [
@@ -93,16 +93,12 @@ def test_get_medication_date_matrix_spot_check(rxdb):
     assert mdm.row_labels == (
         "1001030U0AAABAB",
         "1001030U0AAACAC",
-        "1001030U0AAADAD",
-        "1001030U0AAAEAE",
     )
     assert mdm.col_labels == (date(2025, 3, 1), date(2025, 2, 1))
 
     assert mdm.values.tolist() == [
         [25, 80],
         [7, 5],
-        [0, 0],
-        [0, 0],
     ]
 
 

--- a/tests/data/rxdb/test_labelled_matrix.py
+++ b/tests/data/rxdb/test_labelled_matrix.py
@@ -125,3 +125,16 @@ def test_group_rows_by_label():
 def test_get_row():
     matrix = LabelledMatrix(np.array([[1.0, 2.0], [3.0, 4.0]]), ("A", "B"), (1, 2))
     assert np.array_equal(matrix.get_row("A"), np.array([1.0, 2.0]))
+
+
+def test_drop_zero_rows():
+    matrix = LabelledMatrix(
+        np.array([[1.0, 2.0], [0.0, 0.0], [0.0, 3.0], [np.nan, 0.0]]),
+        ("A", "B", "C", "D"),
+        (1, 2),
+    )
+    assert matrix.drop_zero_rows() == LabelledMatrix(
+        np.array([[1.0, 2.0], [0.0, 3.0], [np.nan, 0.0]]),
+        ("A", "C", "D"),
+        (1, 2),
+    )


### PR DESCRIPTION
If medications match the given query but have no prescribing, they should not be shown in the by-medication chart.

(Because they have no prescribing, they do not appear as areas on the chart of course, but do appear in the chart's legend.)

See https://github.com/bennettoxford/openprescribing/issues/342 for similar discussion in v1.

Addresses #403.

Before and after:

<img width="877" height="584" alt="image" src="https://github.com/user-attachments/assets/ce22cb93-6494-4fdc-b969-4548f6bed27f" />
<img width="877" height="584" alt="image" src="https://github.com/user-attachments/assets/35f6620d-17e4-4182-a9fa-64032f59a65a" />
