### PR TITLE
Filter API responses to filter out metadata from unprescribed medications

### DIFF
--- a/openprescribing/data/models/bnf_codes.py
+++ b/openprescribing/data/models/bnf_codes.py
@@ -61,6 +61,12 @@ class BNFCode(models.Model):
         )
 
     @property
+    def generic_equivalent_code(self):
+        assert self.level == BNFCode.Level.PRESENTATION
+        prefix, suffix = self.code[:9], self.code[-2:]
+        return f"{prefix}AA{suffix}{suffix}"
+
+    @property
     def strength_and_formulation_code(self):
         assert self.level == BNFCode.Level.PRESENTATION
         assert self.is_generic()

--- a/openprescribing/data/models/dmd.py
+++ b/openprescribing/data/models/dmd.py
@@ -21,37 +21,9 @@
 from django.db import models
 
 
-class DmdManager(models.Manager):
-    """Manager for dm+d models."""
-
-    def api_values(self):
-        """Return records shaped for the API."""
-
-        assert hasattr(self.model, "api_attr_mapping"), (
-            f"Cannot serialize {self.model} without an api_attr_mapping class attribute"
-        )
-        mapping = self.model.api_attr_mapping
-        records = self.values(*mapping.keys())
-        return [
-            {api_name: record[attr_name] for attr_name, api_name in mapping.items()}
-            for record in records
-        ]
-
-
-class DmdModel(models.Model):
-    """Abstract base class for dm+d models."""
-
-    objects = DmdManager()
-
-    class Meta:
-        abstract = True
-
-
-class VTM(DmdModel):
+class VTM(models.Model):
     class Meta:
         db_table = "vtm"
-
-    api_attr_mapping = {"vtmid": "id", "nm": "name"}
 
     vtmid = models.BigIntegerField(primary_key=True)
     invalid = models.BooleanField()
@@ -61,11 +33,9 @@ class VTM(DmdModel):
     vtmiddt = models.DateField(null=True)
 
 
-class VMP(DmdModel):
+class VMP(models.Model):
     class Meta:
         db_table = "vmp"
-
-    api_attr_mapping = {"vpid": "id", "vtm_id": "vtm_id", "nm": "name"}
 
     vpid = models.BigIntegerField(primary_key=True)
     vpiddt = models.DateField(null=True)
@@ -144,7 +114,7 @@ class VMP(DmdModel):
     )
 
 
-class VPI(DmdModel):
+class VPI(models.Model):
     class Meta:
         db_table = "vpi"
 
@@ -179,7 +149,7 @@ class VPI(DmdModel):
     )
 
 
-class Ont(DmdModel):
+class Ont(models.Model):
     class Meta:
         db_table = "ont"
 
@@ -191,7 +161,7 @@ class Ont(DmdModel):
     )
 
 
-class Dform(DmdModel):
+class Dform(models.Model):
     class Meta:
         db_table = "dform"
 
@@ -199,7 +169,7 @@ class Dform(DmdModel):
     form = models.ForeignKey(db_column="formcd", to="Form", on_delete=models.CASCADE)
 
 
-class Droute(DmdModel):
+class Droute(models.Model):
     class Meta:
         db_table = "droute"
 
@@ -207,7 +177,7 @@ class Droute(DmdModel):
     route = models.ForeignKey(db_column="routecd", to="Route", on_delete=models.CASCADE)
 
 
-class ControlInfo(DmdModel):
+class ControlInfo(models.Model):
     class Meta:
         db_table = "control_info"
 
@@ -227,11 +197,9 @@ class ControlInfo(DmdModel):
     )
 
 
-class AMP(DmdModel):
+class AMP(models.Model):
     class Meta:
         db_table = "amp"
-
-    api_attr_mapping = {"apid": "id", "vmp_id": "vmp_id", "descr": "name"}
 
     apid = models.BigIntegerField(primary_key=True)
     invalid = models.BooleanField()
@@ -286,7 +254,7 @@ class AMP(DmdModel):
     )
 
 
-class LicRoute(DmdModel):
+class LicRoute(models.Model):
     class Meta:
         db_table = "lic_route"
 
@@ -298,7 +266,7 @@ class LicRoute(DmdModel):
     )
 
 
-class ApInfo(DmdModel):
+class ApInfo(models.Model):
     class Meta:
         db_table = "ap_info"
 
@@ -313,7 +281,7 @@ class ApInfo(DmdModel):
     prod_order_no = models.CharField(max_length=20, null=True)
 
 
-class VMPP(DmdModel):
+class VMPP(models.Model):
     class Meta:
         db_table = "vmpp"
 
@@ -338,7 +306,7 @@ class VMPP(DmdModel):
     )
 
 
-class Dtinfo(DmdModel):
+class Dtinfo(models.Model):
     class Meta:
         db_table = "dtinfo"
 
@@ -353,7 +321,7 @@ class Dtinfo(DmdModel):
     prevprice = models.IntegerField(null=True)
 
 
-class AMPP(DmdModel):
+class AMPP(models.Model):
     class Meta:
         db_table = "ampp"
 
@@ -384,7 +352,7 @@ class AMPP(DmdModel):
     discdt = models.DateField(null=True)
 
 
-class PackInfo(DmdModel):
+class PackInfo(models.Model):
     class Meta:
         db_table = "pack_info"
 
@@ -405,7 +373,7 @@ class PackInfo(DmdModel):
     pack_order_no = models.CharField(max_length=20, null=True)
 
 
-class PrescribInfo(DmdModel):
+class PrescribInfo(models.Model):
     class Meta:
         db_table = "prescrib_info"
 
@@ -421,7 +389,7 @@ class PrescribInfo(DmdModel):
     dent_f = models.BooleanField()
 
 
-class PriceInfo(DmdModel):
+class PriceInfo(models.Model):
     class Meta:
         db_table = "price_info"
 
@@ -436,7 +404,7 @@ class PriceInfo(DmdModel):
     )
 
 
-class ReimbInfo(DmdModel):
+class ReimbInfo(models.Model):
     class Meta:
         db_table = "reimb_info"
 
@@ -462,11 +430,9 @@ class ReimbInfo(DmdModel):
     fp34d = models.BooleanField()
 
 
-class Ing(DmdModel):
+class Ing(models.Model):
     class Meta:
         db_table = "ing"
-
-    api_attr_mapping = {"isid": "id", "nm": "name"}
 
     isid = models.BigIntegerField(primary_key=True)
     isiddt = models.DateField(null=True)
@@ -475,7 +441,7 @@ class Ing(DmdModel):
     nm = models.CharField(max_length=255)
 
 
-class CombinationPackInd(DmdModel):
+class CombinationPackInd(models.Model):
     class Meta:
         db_table = "combination_pack_ind"
 
@@ -483,7 +449,7 @@ class CombinationPackInd(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class CombinationProdInd(DmdModel):
+class CombinationProdInd(models.Model):
     class Meta:
         db_table = "combination_prod_ind"
 
@@ -491,7 +457,7 @@ class CombinationProdInd(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class BasisOfName(DmdModel):
+class BasisOfName(models.Model):
     class Meta:
         db_table = "basis_of_name"
 
@@ -499,7 +465,7 @@ class BasisOfName(DmdModel):
     descr = models.CharField(max_length=150)
 
 
-class NamechangeReason(DmdModel):
+class NamechangeReason(models.Model):
     class Meta:
         db_table = "namechange_reason"
 
@@ -508,7 +474,7 @@ class NamechangeReason(DmdModel):
     descr = models.CharField(max_length=150, null=True)
 
 
-class VirtualProductPresStatus(DmdModel):
+class VirtualProductPresStatus(models.Model):
     class Meta:
         db_table = "virtual_product_pres_status"
 
@@ -516,7 +482,7 @@ class VirtualProductPresStatus(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class ControlDrugCategory(DmdModel):
+class ControlDrugCategory(models.Model):
     class Meta:
         db_table = "control_drug_category"
 
@@ -524,7 +490,7 @@ class ControlDrugCategory(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class LicensingAuthority(DmdModel):
+class LicensingAuthority(models.Model):
     class Meta:
         db_table = "licensing_authority"
 
@@ -532,7 +498,7 @@ class LicensingAuthority(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class UnitOfMeasure(DmdModel):
+class UnitOfMeasure(models.Model):
     class Meta:
         db_table = "unit_of_measure"
 
@@ -542,7 +508,7 @@ class UnitOfMeasure(DmdModel):
     descr = models.CharField(max_length=150)
 
 
-class Form(DmdModel):
+class Form(models.Model):
     class Meta:
         db_table = "form"
 
@@ -552,17 +518,15 @@ class Form(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class OntFormRoute(DmdModel):
+class OntFormRoute(models.Model):
     class Meta:
         db_table = "ont_form_route"
-
-    api_attr_mapping = {"cd": "id", "descr": "descr"}
 
     cd = models.IntegerField(primary_key=True)
     descr = models.CharField(max_length=60)
 
 
-class Route(DmdModel):
+class Route(models.Model):
     class Meta:
         db_table = "route"
 
@@ -572,7 +536,7 @@ class Route(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class DtPaymentCategory(DmdModel):
+class DtPaymentCategory(models.Model):
     class Meta:
         db_table = "dt_payment_category"
 
@@ -580,7 +544,7 @@ class DtPaymentCategory(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class Supplier(DmdModel):
+class Supplier(models.Model):
     class Meta:
         db_table = "supplier"
 
@@ -591,7 +555,7 @@ class Supplier(DmdModel):
     descr = models.CharField(max_length=80)
 
 
-class Flavour(DmdModel):
+class Flavour(models.Model):
     class Meta:
         db_table = "flavour"
 
@@ -599,7 +563,7 @@ class Flavour(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class Colour(DmdModel):
+class Colour(models.Model):
     class Meta:
         db_table = "colour"
 
@@ -607,7 +571,7 @@ class Colour(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class BasisOfStrnth(DmdModel):
+class BasisOfStrnth(models.Model):
     class Meta:
         db_table = "basis_of_strnth"
 
@@ -615,7 +579,7 @@ class BasisOfStrnth(DmdModel):
     descr = models.CharField(max_length=150)
 
 
-class ReimbursementStatus(DmdModel):
+class ReimbursementStatus(models.Model):
     class Meta:
         db_table = "reimbursement_status"
 
@@ -623,7 +587,7 @@ class ReimbursementStatus(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class SpecCont(DmdModel):
+class SpecCont(models.Model):
     class Meta:
         db_table = "spec_cont"
 
@@ -631,7 +595,7 @@ class SpecCont(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class Dnd(DmdModel):
+class Dnd(models.Model):
     class Meta:
         db_table = "dnd"
 
@@ -639,7 +603,7 @@ class Dnd(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class VirtualProductNonAvail(DmdModel):
+class VirtualProductNonAvail(models.Model):
     class Meta:
         db_table = "virtual_product_non_avail"
 
@@ -647,7 +611,7 @@ class VirtualProductNonAvail(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class DiscontinuedInd(DmdModel):
+class DiscontinuedInd(models.Model):
     class Meta:
         db_table = "discontinued_ind"
 
@@ -655,7 +619,7 @@ class DiscontinuedInd(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class DfIndicator(DmdModel):
+class DfIndicator(models.Model):
     class Meta:
         db_table = "df_indicator"
 
@@ -663,7 +627,7 @@ class DfIndicator(DmdModel):
     descr = models.CharField(max_length=20)
 
 
-class PriceBasis(DmdModel):
+class PriceBasis(models.Model):
     class Meta:
         db_table = "price_basis"
 
@@ -671,7 +635,7 @@ class PriceBasis(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class LegalCategory(DmdModel):
+class LegalCategory(models.Model):
     class Meta:
         db_table = "legal_category"
 
@@ -679,7 +643,7 @@ class LegalCategory(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class AvailabilityRestriction(DmdModel):
+class AvailabilityRestriction(models.Model):
     class Meta:
         db_table = "availability_restriction"
 
@@ -687,7 +651,7 @@ class AvailabilityRestriction(DmdModel):
     descr = models.CharField(max_length=60)
 
 
-class LicensingAuthorityChangeReason(DmdModel):
+class LicensingAuthorityChangeReason(models.Model):
     class Meta:
         db_table = "licensing_authority_change_reason"
 

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -22,6 +22,20 @@ DATE_COUNT = 96
 # stacked area chart.  Any further medications are summed into a single "Other" band.
 MEDICATIONS_TOP_N = 10
 
+# Selects medications that have been prescribed: VMPs/AMPs whose BNF code appears in the
+# prescribing data, plus the parent VMPs of any prescribed AMPs.
+PRESCRIBED_MEDICATIONS_SQL = """
+    SELECT * FROM medications
+    WHERE bnf_code IN (SELECT bnf_code FROM presentation)
+    OR (
+        NOT is_amp
+        AND id IN (
+            SELECT DISTINCT vmp_id FROM medications
+            WHERE is_amp AND bnf_code IN (SELECT bnf_code FROM presentation)
+        )
+    )
+"""
+
 
 def _get_org(analysis):
     org_id = analysis.org_id
@@ -145,27 +159,7 @@ def _metadata_medications_payload():
     """
     with rxdb.get_cursor() as cursor:
         medications = (
-            cursor.sql(
-                """
-                SELECT * FROM medications
-                WHERE bnf_code IN (
-                    SELECT bnf_code FROM presentation
-                )
-                OR (
-                    NOT is_amp
-                    AND id IN (
-                        SELECT DISTINCT vmp_id
-                        FROM medications
-                        WHERE is_amp
-                        AND bnf_code IN (
-                            SELECT bnf_code FROM presentation
-                        )
-                    )
-                )
-                """
-            )
-            .to_arrow_table()
-            .to_pylist()
+            cursor.sql(PRESCRIBED_MEDICATIONS_SQL).to_arrow_table().to_pylist()
         )
     return {"medications": medications}
 

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -171,20 +171,39 @@ def metadata_dmd(request):
 
 @cache
 def _metadata_dmd_payload():
-    """Return details of dm+d objects that will be used to query and display
-    medications."""
+    """Return details of the dm+d objects relating to prescribed medications.
+
+    This will be used to query and display medications.
+    """
 
     queries = {
-        "vtm": "SELECT vtmid AS id, nm AS name FROM vtm",
-        "vmp": "SELECT vpid AS id, vtmid AS vtm_id, nm AS name FROM vmp",
-        "amp": "SELECT apid AS id, vpid AS vmp_id, descr AS name FROM amp",
-        "ingredient": "SELECT isid AS id, nm AS name FROM ing",
-        "ont_form_route": "SELECT cd AS id, descr FROM ont_form_route",
+        "vtm": """
+            SELECT vtm.vtmid AS id, vtm.nm AS name
+            FROM vtm
+            WHERE vtm.vtmid IN (
+                SELECT vtm_id FROM prescribed WHERE vtm_id IS NOT NULL
+            )
+        """,
+        "vmp": "SELECT id, vtm_id, name FROM prescribed WHERE NOT is_amp",
+        "amp": "SELECT id, vmp_id, name FROM prescribed WHERE is_amp",
+        "ingredient": """
+            SELECT DISTINCT ing.isid AS id, ing.nm AS name
+            FROM ing
+            JOIN vpi ON vpi.isid = ing.isid
+            WHERE vpi.vpid IN (SELECT vmp_id FROM prescribed)
+        """,
+        "ont_form_route": """
+            SELECT DISTINCT ont_form_route.cd AS id, ont_form_route.descr AS descr
+            FROM ont_form_route
+            JOIN ont ON ont.formcd = ont_form_route.cd
+            WHERE ont.vpid IN (SELECT vmp_id FROM prescribed)
+        """,
     }
     payload = {}
     with rxdb.get_cursor() as cursor:
         for key, sql in queries.items():
-            payload[key] = cursor.sql(sql).to_arrow_table().to_pylist()
+            full_sql = f"WITH prescribed AS ({PRESCRIBED_MEDICATIONS_SQL}) {sql}"
+            payload[key] = cursor.sql(full_sql).to_arrow_table().to_pylist()
     return payload
 
 

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -214,34 +214,55 @@ def metadata_bnf(request):
 
 @cache
 def _metadata_bnf_payload():
-    """Return details of BNF objects that will be used to query and display
-    medications.
+    """Return details of the BNF objects relating to prescribed medications.
 
     In order to handle strength and formulation equivalents, we replace the records for
     level 6 objects (ie BNF products) with records for strength and formulation
     equivalents.
 
     Chapters 20 to 23 (devices rather than medicines) have a slightly different code
-    structure, and so will need to be handled slightly differently. k
+    structure, and so will need to be handled slightly differently.
     """
 
-    base_queryset = BNFCode.objects.exclude(code__startswith="2").order_by(
-        "level", "code"
-    )
+    presentation_sql = f"""
+        WITH prescribed AS ({PRESCRIBED_MEDICATIONS_SQL})
+        SELECT code, level, name
+        FROM bnf_code
+        WHERE level = {BNFCode.Level.PRESENTATION}
+        AND code NOT LIKE '2%'
+        AND code IN (SELECT DISTINCT bnf_code FROM prescribed WHERE bnf_code IS NOT NULL)
+        ORDER BY code
+    """
+    with rxdb.get_cursor() as cursor:
+        presentation_records = cursor.sql(presentation_sql).to_arrow_table().to_pylist()
+
+    # Wrapping each presentation in an unsaved BNFCode allows us to reuse its strength
+    # and formulation logic.
+    presentations = [BNFCode(**record) for record in presentation_records]
+
+    generic_equivalent_codes = {p.generic_equivalent_code for p in presentations}
+    generic_presentations = BNFCode.objects.filter(code__in=generic_equivalent_codes)
     strength_and_formulation_records = [
         {
-            "code": code.strength_and_formulation_code,
+            "code": presentation.strength_and_formulation_code,
             "level": 6,
-            "name": code.strength_and_formulation_name,
+            "name": presentation.strength_and_formulation_name,
         }
-        for code in base_queryset.filter(level=BNFCode.Level.PRESENTATION)
-        if code.is_generic()
+        for presentation in generic_presentations
     ]
-    records = (
-        list(base_queryset.filter(level__lte=BNFCode.Level.CHEMICAL_SUBSTANCE).values())
-        + strength_and_formulation_records
-        + list(base_queryset.filter(level=BNFCode.Level.PRESENTATION).values())
+
+    ancestor_codes = {
+        presentation.code[:length]
+        for presentation in presentations
+        for length in (2, 4, 6, 7, 9)
+    }
+    ancestor_records = list(
+        BNFCode.objects.filter(code__in=ancestor_codes)
+        .order_by("level", "code")
+        .values()
     )
+
+    records = ancestor_records + strength_and_formulation_records + presentation_records
     return {"bnf": records}
 
 

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -11,7 +11,7 @@ from openprescribing.data.queries import (
     get_medication_date_matrix,
     get_org_date_ratio_matrix,
 )
-from openprescribing.web.decorators import add_cache_headers
+from openprescribing.web.decorators import add_cache_headers, cache
 
 
 # We currently have about 8 years (96 months) of list size data.  In future we could
@@ -133,6 +133,11 @@ def _get_top_n_row_label_map(mdm, n):
 
 @add_cache_headers
 def metadata_medications(request):
+    return JsonResponse(_metadata_medications_payload())
+
+
+@cache
+def _metadata_medications_payload():
     """Return details of all medications that have been prescribed.
 
     Include VMPs for any prescribed AMPs, even if the VMP itself has not been
@@ -162,26 +167,35 @@ def metadata_medications(request):
             .to_arrow_table()
             .to_pylist()
         )
-    return JsonResponse({"medications": medications})
+    return {"medications": medications}
 
 
 @add_cache_headers
 def metadata_dmd(request):
+    return JsonResponse(_metadata_dmd_payload())
+
+
+@cache
+def _metadata_dmd_payload():
     """Return details of dm+d objects that will be used to query and display
     medications."""
 
-    payload = {
+    return {
         "vtm": VTM.objects.api_values(),
         "vmp": VMP.objects.api_values(),
         "amp": AMP.objects.api_values(),
         "ingredient": Ing.objects.api_values(),
         "ont_form_route": OntFormRoute.objects.api_values(),
     }
-    return JsonResponse(payload)
 
 
 @add_cache_headers
 def metadata_bnf(request):
+    return JsonResponse(_metadata_bnf_payload())
+
+
+@cache
+def _metadata_bnf_payload():
     """Return details of BNF objects that will be used to query and display
     medications.
 
@@ -210,7 +224,7 @@ def metadata_bnf(request):
         + strength_and_formulation_records
         + list(base_queryset.filter(level=BNFCode.Level.PRESENTATION).values())
     )
-    return JsonResponse({"bnf": records})
+    return {"bnf": records}
 
 
 class JsonResponse(DjangoJsonResponse):

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -6,7 +6,7 @@ from django.http import JsonResponse as DjangoJsonResponse
 
 from openprescribing.data import rxdb
 from openprescribing.data.analysis import Analysis
-from openprescribing.data.models import AMP, VMP, VTM, BNFCode, Ing, OntFormRoute, Org
+from openprescribing.data.models import BNFCode, Org
 from openprescribing.data.queries import (
     get_medication_date_matrix,
     get_org_date_ratio_matrix,
@@ -174,13 +174,18 @@ def _metadata_dmd_payload():
     """Return details of dm+d objects that will be used to query and display
     medications."""
 
-    return {
-        "vtm": VTM.objects.api_values(),
-        "vmp": VMP.objects.api_values(),
-        "amp": AMP.objects.api_values(),
-        "ingredient": Ing.objects.api_values(),
-        "ont_form_route": OntFormRoute.objects.api_values(),
+    queries = {
+        "vtm": "SELECT vtmid AS id, nm AS name FROM vtm",
+        "vmp": "SELECT vpid AS id, vtmid AS vtm_id, nm AS name FROM vmp",
+        "amp": "SELECT apid AS id, vpid AS vmp_id, descr AS name FROM amp",
+        "ingredient": "SELECT isid AS id, nm AS name FROM ing",
+        "ont_form_route": "SELECT cd AS id, descr FROM ont_form_route",
     }
+    payload = {}
+    with rxdb.get_cursor() as cursor:
+        for key, sql in queries.items():
+            payload[key] = cursor.sql(sql).to_arrow_table().to_pylist()
+    return payload
 
 
 @add_cache_headers

--- a/openprescribing/web/decorators.py
+++ b/openprescribing/web/decorators.py
@@ -1,8 +1,30 @@
+import functools
+
 from django.conf import settings
 from django.views.decorators.cache import cache_control
 from django.views.decorators.http import etag
 
 from openprescribing.data import rxdb
+
+
+def cache(fn):
+    """Cache a no-argument function's return value in memory until the underlying data
+    changes.
+
+    Unlike add_cache_headers, we don't include settings.VERSION in the cache key,
+    because if this changes, the server will be restarted and the in-memory cache will
+    be cleared.
+    """
+
+    @functools.lru_cache(maxsize=1)
+    def cached(cache_key):
+        return fn()
+
+    @functools.wraps(fn)
+    def wrapper():
+        return cached(rxdb.get_cache_key())
+
+    return wrapper
 
 
 def add_cache_headers(view_fn):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import datetime
+import itertools
 
 import pytest
 
@@ -52,13 +53,21 @@ def prevent_rxdb_access():
             "use the `rxdb` fixture to enable it"
         )
 
-    def get_cache_key():
-        return (0.0, 0.0)
-
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr(openprescribing.data.rxdb, "get_cursor", get_cursor)
-        monkeypatch.setattr(openprescribing.data.rxdb, "get_cache_key", get_cache_key)
         yield
+
+
+_cache_key_counter = itertools.count()
+
+
+@pytest.fixture(autouse=True)
+def cache_key(monkeypatch):
+    # Give each test a distinct, stable cache key so the caches keyed on it (see
+    # openprescribing.web.decorators.cache) don't serve one test's data to the
+    # next.
+    cache_key = (next(_cache_key_counter), 0.0)
+    monkeypatch.setattr(openprescribing.data.rxdb, "get_cache_key", lambda: cache_key)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
-import datetime
 import itertools
 
 import pytest
 
 import openprescribing.data.rxdb
-from openprescribing.data.models import BNFCode, Org, OrgRelation
+from openprescribing.data.models import BNFCode
+from tests.utils.data_utils import generate_test_data
 from tests.utils.ingest_utils import ingest_dmd_bnf_map_data, ingest_dmd_data
 from tests.utils.medications_utils import MedicationsBuilder
 from tests.utils.rxdb_utils import RXDBFixture
@@ -147,52 +147,12 @@ def sample_data(rxdb, bnf_codes):
 
     This data should be just about rich enough for the tests of the website and API.
     """
-
-    list_size_data = []
-    prescribing_data = []
-
-    for icb_ix in range(2):
-        icb = Org.objects.create(
-            id=f"ICB{icb_ix:02}",
-            name=f"ICB {icb_ix}",
-            org_type=Org.OrgType.ICB,
-        )
-        for pra_ix in range(2):
-            pra = Org.objects.create(
-                id=f"PRA{icb_ix}{pra_ix}",
-                name=f"Practice {icb_ix}{pra_ix}",
-                org_type=Org.OrgType.PRACTICE,
-            )
-            OrgRelation.objects.create(child=pra, parent=icb)
-            for month in (1, 2, 3):
-                date = datetime.date(2025, month, 1)
-                list_size_data.append(
-                    {
-                        "date": date,
-                        "practice_code": pra.id,
-                        "total": 1000 + 100 * icb_ix + 10 * pra_ix + month,
-                    }
-                )
-                for bnf_ix, bnf_code in enumerate(
-                    [
-                        "1001030U0AAABAB",
-                        "1001030U0AAACAC",
-                        "1001030U0BDAAAB",
-                        "1001030U0BDABAC",
-                    ]
-                ):
-                    prescribing_data.append(
-                        {
-                            "date": date,
-                            "bnf_code": bnf_code,
-                            "practice_code": pra.id,
-                            "items": 8 * bnf_ix + 4 * icb_ix + 2 * pra_ix + month,
-                        },
-                    )
-
-    rxdb.ingest(
-        list_size_data=list_size_data,
-        prescribing_data=prescribing_data,
+    return generate_test_data(
+        rxdb,
+        [
+            "1001030U0AAABAB",
+            "1001030U0AAACAC",
+            "1001030U0BDAAAB",
+            "1001030U0BDABAC",
+        ],
     )
-
-    return {"list_size_data": list_size_data, "prescribing_data": prescribing_data}

--- a/tests/data/models/test_bnf_codes.py
+++ b/tests/data/models/test_bnf_codes.py
@@ -47,6 +47,11 @@ def test_is_generic_equivalent_of():
     )
 
 
+def test_generic_equivalent_code():
+    assert bnf_code("1001030U0BDAAAB").generic_equivalent_code == "1001030U0AAABAB"
+    assert bnf_code("1001030U0AAABAB").generic_equivalent_code == "1001030U0AAABAB"
+
+
 def test_strength_and_formulation_code():
     assert bnf_code("1001030U0AAABAB").strength_and_formulation_code == "1001030U0_AB"
 

--- a/tests/functional/test_analysis.py
+++ b/tests/functional/test_analysis.py
@@ -1,6 +1,7 @@
 import pytest
 from playwright.sync_api import expect
 
+from tests.utils.data_utils import generate_test_data
 from tests.utils.ingest_utils import ingest_dmd_bnf_map_data, ingest_dmd_data
 
 
@@ -8,10 +9,12 @@ pytestmark = pytest.mark.functional
 
 
 @pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
-def test_analysis(live_server, page, sample_data, settings, tmp_path):
+def test_analysis(live_server, page, rxdb, settings, tmp_path):
     # This is a limited smoke test that walks through building a simple analysis from
     # the landing page and verifies that the resulting analysis page renders a chart.
 
+    adenosine_bnf_codes = ["0203020C0AAAAAA", "0203020C0BBAAAA"]
+    generate_test_data(rxdb, adenosine_bnf_codes)
     ingest_dmd_data(settings, tmp_path)
     ingest_dmd_bnf_map_data(settings, tmp_path)
 

--- a/tests/functional/test_build_analysis.py
+++ b/tests/functional/test_build_analysis.py
@@ -55,10 +55,8 @@ def test_build_analyse_has_dynamic_filters_and_independent_queries(
     expect(
         dropdown_option_elements(numerator_panel, "BNF hierarchy").first
     ).to_be_visible()
-    assert dropdown_option_texts(numerator_panel, "BNF hierarchy")[:4] == [
-        "Anaesthesia (Chapter)",
+    assert dropdown_option_texts(numerator_panel, "BNF hierarchy")[:2] == [
         "Cardiovascular System (Chapter)",
-        "Endocrine System (Chapter)",
         "Eye (Chapter)",
     ]
     dropdown_input(numerator_panel, "BNF hierarchy").fill("1106000X0")
@@ -305,8 +303,10 @@ def ingest_build_analysis_bnf_data():
         [1, "15", "Anaesthesia"],
         [2, "0203", "Paroxysmal supraventricular tachycardias"],
         [5, "0203020C0", "Adenosine"],
+        [7, "0203020C0BBAAAA", "Adenocor 6mg/2ml solution for injection vials"],
         [2, "1106", "Glaucoma and ocular hypertension"],
         [5, "1106000X0", "Pilocarpine"],
+        [7, "1106000X0AAA4A4", "Pilocarpine 6% eye drops"],
     ]:
         BNFCode.objects.create(code=code, name=name, level=level)
 

--- a/tests/utils/data_utils.py
+++ b/tests/utils/data_utils.py
@@ -1,0 +1,62 @@
+import datetime
+
+from openprescribing.data.models import BNFCode, Org, OrgRelation
+
+
+def generate_test_data(rxdb, bnf_codes):
+    """Generate and ingest list size and prescribing data for the given presentation BNF
+    codes.
+
+    Generates three months (Jan-Mar 2025) of list size data, and prescribing data for
+    each of `bnf_codes`, across four practices in two ICBs.  This should be just about
+    rich enough for the tests of the website and API.
+
+    Returns a dict of the generated data so callers can compute expected values from it.
+    """
+    for code in bnf_codes:
+        BNFCode.objects.get_or_create(
+            code=code,
+            defaults={"name": code, "level": BNFCode.Level.PRESENTATION},
+        )
+
+    list_size_data = []
+    prescribing_data = []
+
+    for icb_ix in range(2):
+        icb = Org.objects.create(
+            id=f"ICB{icb_ix:02}",
+            name=f"ICB {icb_ix}",
+            org_type=Org.OrgType.ICB,
+        )
+        for pra_ix in range(2):
+            pra = Org.objects.create(
+                id=f"PRA{icb_ix}{pra_ix}",
+                name=f"Practice {icb_ix}{pra_ix}",
+                org_type=Org.OrgType.PRACTICE,
+            )
+            OrgRelation.objects.create(child=pra, parent=icb)
+            for month in (1, 2, 3):
+                date = datetime.date(2025, month, 1)
+                list_size_data.append(
+                    {
+                        "date": date,
+                        "practice_code": pra.id,
+                        "total": 1000 + 100 * icb_ix + 10 * pra_ix + month,
+                    }
+                )
+                for bnf_ix, bnf_code in enumerate(bnf_codes):
+                    prescribing_data.append(
+                        {
+                            "date": date,
+                            "bnf_code": bnf_code,
+                            "practice_code": pra.id,
+                            "items": 8 * bnf_ix + 4 * icb_ix + 2 * pra_ix + month,
+                        },
+                    )
+
+    rxdb.ingest(
+        list_size_data=list_size_data,
+        prescribing_data=prescribing_data,
+    )
+
+    return {"list_size_data": list_size_data, "prescribing_data": prescribing_data}

--- a/tests/utils/medications_utils.py
+++ b/tests/utils/medications_utils.py
@@ -1,13 +1,17 @@
 from openprescribing.data.models import (
+    AMP,
     VMP,
     VPI,
     VTM,
+    AvailabilityRestriction,
     BasisOfName,
     BNFCode,
     DmdBnfMap,
     Ing,
+    LicensingAuthority,
     Ont,
     OntFormRoute,
+    Supplier,
     VirtualProductPresStatus,
 )
 
@@ -17,8 +21,6 @@ class MedicationsBuilder:
     the underlying tables.
 
     It can be used in tests via the medications fixture.
-
-    At the moment we only support adding VMPs.  Adding AMPs would be straightforward.
     """
 
     def __init__(self):
@@ -27,7 +29,12 @@ class MedicationsBuilder:
         self._form_route_cds = {}
 
     def add_rows(self, rows):
-        """This method should be called in tests to populate the underlying tables."""
+        """This method should be called in tests to populate the underlying tables.
+
+        Each row is a dict describing either a VMP or an AMP.  A row with a truthy
+        `is_amp` key is added as an AMP belonging to an existing VMP (identified by its
+        `vmp_id`); any other row is added as a VMP.
+        """
 
         # There are non-nullable FKs from VMP to these tables, so we need to have
         # records in the database.
@@ -35,9 +42,13 @@ class MedicationsBuilder:
         VirtualProductPresStatus.objects.get_or_create(cd=0, defaults={"descr": ""})
 
         for row in rows:
-            self._add_row(**row)
+            row = dict(row)
+            if row.pop("is_amp", False):
+                self._add_amp(**row)
+            else:
+                self._add_vmp(**row)
 
-    def _add_row(
+    def _add_vmp(
         self,
         *,
         bnf_code=None,
@@ -82,6 +93,40 @@ class MedicationsBuilder:
         for descr in form_routes:
             formcd = self._get_or_create_form_route_cd(descr)
             Ont.objects.create(vmp_id=dmd_id, form_id=formcd)
+
+    def _add_amp(self, *, vmp_id, bnf_code=None, name="", invalid=False):
+        # There are non-nullable FKs from AMP to these tables, so we need to have
+        # records in the database.
+        Supplier.objects.get_or_create(cd=0, defaults={"descr": "", "invalid": False})
+        LicensingAuthority.objects.get_or_create(cd=0, defaults={"descr": ""})
+        AvailabilityRestriction.objects.get_or_create(cd=0, defaults={"descr": ""})
+
+        apid = self._next_id
+        self._next_id += 1
+
+        # An AMP shares its VMP's BNF code unless one is given explicitly.
+        if bnf_code is None:  # pragma: no cover
+            bnf_code = DmdBnfMap.objects.get(dmd_id=vmp_id).bnf_code
+
+        BNFCode.objects.get_or_create(
+            code=bnf_code,
+            defaults={"name": "", "level": BNFCode.Level.PRESENTATION},
+        )
+
+        DmdBnfMap.objects.create(dmd_id=apid, bnf_code=bnf_code)
+
+        AMP.objects.create(
+            apid=apid,
+            vmp_id=vmp_id,
+            nm=name,
+            descr=name,
+            invalid=invalid,
+            supp_id=0,
+            lic_auth_id=0,
+            avail_restrict_id=0,
+            ema=False,
+            parallel_import=False,
+        )
 
     def _get_or_create_form_route_cd(self, descr):
         # Assign a stable cd to each form/route description so that the medications

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -286,7 +286,13 @@ def test_metadata_dmd(client, rxdb, medications):
     assert [record["descr"] for record in payload["ont_form_route"]] == ["tablet.oral"]
 
 
-def test_metadata_bnf(client, bnf_codes):
+def test_metadata_bnf(client, rxdb, bnf_codes, medications):
+    # The bnf_codes fixture provides the BNF hierarchy; we also need to link a VMP to a
+    # generic methotrexate presentation and prescribe it so that appears in the
+    # medications view.
+    medications.add_rows([{"bnf_code": "1001030U0BDAAAB"}])
+    rxdb.ingest([{"bnf_code": "1001030U0BDAAAB"}])
+
     rsp = client.get("/api/metadata/bnf/")
     payload = rsp.json()
     assert {
@@ -309,6 +315,12 @@ def test_metadata_bnf(client, bnf_codes):
         "level": 7,
         "name": "Maxtrex 2.5mg tablets",
     } in payload["bnf"]
+
+    # Codes unrelated to prescribed medications are excluded: another (unprescribed)
+    # methotrexate presentation and the entire diabetic-testing branch.
+    codes = {record["code"] for record in payload["bnf"]}
+    assert "1001030U0AAACAC" not in codes
+    assert "0601060D0" not in codes
 
 
 def test_nans_to_nones():

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -247,8 +247,7 @@ def test_metadata_medications(client, rxdb, settings, tmp_path):
     } in payload["medications"]
 
 
-@pytest.mark.django_db(databases=["data"])
-def test_metadata_dmd(client, settings, tmp_path):
+def test_metadata_dmd(client, rxdb, settings, tmp_path):
     ingest_dmd_data(settings, tmp_path)
     rsp = client.get("/api/metadata/dmd/")
     payload = rsp.json()

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -247,31 +247,43 @@ def test_metadata_medications(client, rxdb, settings, tmp_path):
     } in payload["medications"]
 
 
-def test_metadata_dmd(client, rxdb, settings, tmp_path):
-    ingest_dmd_data(settings, tmp_path)
-    rsp = client.get("/api/metadata/dmd/")
-    payload = rsp.json()
-    assert {
-        "id": 108502004,
-        "name": "Adenosine",
-    } in payload["vtm"]
-    assert {
-        "id": 35894711000001106,
-        "vtm_id": 108502004,
-        "name": "Adenosine 6mg/2ml solution for injection vials",
-    } in payload["vmp"]
-    assert {
-        "id": 4744411000001104,
-        "vmp_id": 35894711000001106,
-        "name": "Adenocor 6mg/2ml solution for injection vials (Sanofi)",
-    } in payload["amp"]
-    assert {
-        "id": 35431001,
-        "name": "Adenosine",
-    } in payload["ingredient"]
-    assert {"id": 24, "descr": "solutioninjection.intravenous"} in payload[
-        "ont_form_route"
-    ]
+def test_metadata_dmd(client, rxdb, medications):
+    # Two VMPs with distinct VTMs, ingredients and form/routes, plus an AMP belonging to
+    # the first VMP; only the first VMP (and hence its AMP) is then prescribed.
+    medications.add_rows(
+        [
+            {
+                "bnf_code": "1001030U0AAABAB",
+                "name": "Prescribed VMP",
+                "vtm_id": 1,
+                "ingredient_ids": [10],
+                "form_routes": ["tablet.oral"],
+            },
+            {
+                "bnf_code": "1001030U0AAACAC",
+                "name": "Unprescribed VMP",
+                "vtm_id": 2,
+                "ingredient_ids": [11],
+                "form_routes": ["cream.topical"],
+            },
+            {
+                "is_amp": True,
+                "vmp_id": 1,
+                "name": "Prescribed AMP",
+            },
+        ]
+    )
+    rxdb.ingest([{"bnf_code": "1001030U0AAABAB"}])
+
+    payload = client.get("/api/metadata/dmd/").json()
+
+    # Only the prescribed VMP, its AMP, and the VTM, ingredient and form/route they
+    # relate to are returned; the unprescribed VMP's objects are excluded.
+    assert payload["vmp"] == [{"id": 1, "vtm_id": 1, "name": "Prescribed VMP"}]
+    assert payload["amp"] == [{"id": 3, "vmp_id": 1, "name": "Prescribed AMP"}]
+    assert {record["id"] for record in payload["vtm"]} == {1}
+    assert {record["id"] for record in payload["ingredient"]} == {10}
+    assert [record["descr"] for record in payload["ont_form_route"]] == ["tablet.oral"]
 
 
 def test_metadata_bnf(client, bnf_codes):

--- a/tests/web/test_decorators.py
+++ b/tests/web/test_decorators.py
@@ -2,7 +2,7 @@ import pytest
 from django.http import HttpResponse
 from django.test import RequestFactory
 
-from openprescribing.web.decorators import add_cache_headers
+from openprescribing.web.decorators import add_cache_headers, cache
 
 
 @add_cache_headers
@@ -20,6 +20,27 @@ def patch_cache_key(monkeypatch):
         )
 
     return patch
+
+
+def test_cache(patch_cache_key):
+    calls = 0
+
+    @cache
+    def fn():
+        nonlocal calls
+        calls += 1
+
+    patch_cache_key("aaaaaaa", 100.0, 200.0)
+    fn()
+    assert calls == 1
+    fn()
+    assert calls == 1
+
+    patch_cache_key("aaaaaaa", 300.0, 400.0)
+    fn()
+    assert calls == 2
+    fn()
+    assert calls == 2
 
 
 def test_etag_and_cache_control_headers_on_200(patch_cache_key):


### PR DESCRIPTION
This should reduce the amount of thinking that users have to do when building queries.  For instance, the ingredients filter no longer has lots of ingredients with no prescribing at the top:

Before:

<img width="444" height="362" alt="image" src="https://github.com/user-attachments/assets/723e69d4-fccb-4021-a8f0-5bb4f81f5fa4" />

After:

<img width="444" height="362" alt="image" src="https://github.com/user-attachments/assets/de2968b5-ac36-4594-b0df-e94538d47c51" />
