### PR TITLE
Add `ProfilingConnection`

### DIFF
--- a/openprescribing/data/utils/duckdb_utils.py
+++ b/openprescribing/data/utils/duckdb_utils.py
@@ -1,3 +1,7 @@
+import itertools
+from pathlib import Path
+
+
 # Types taken from:
 # https://duckdb.org/docs/stable/sql/data_types/numeric
 UNSIGNED_INTEGER_TYPES = {"utinyint", "usmallint", "uinteger", "ubigint", "uhugeint"}
@@ -11,3 +15,40 @@ def escape(s):
     # DuckDB doesn't accept parameter placeholders for filenames in queries so we have
     # to escape them manually
     return "'" + str(s).replace("'", "''") + "'"
+
+
+class ProfilingConnection:
+    """
+    This class wraps an instance of `DuckDBPyConnection` and writes profiling
+    information to a JSON file each time the `.sql` method is called.
+
+    For example:
+
+    ```python
+    conn = ProfilingConnection(duckdb.connect(), "queries")
+    conn.sql("SELECT ...")  # writes queries/query_001.json
+    conn.sql("SELECT ...")  # writes queries/query_002.json
+
+    This class is intended for experimental use; either locally or in a production-like
+    environment, wrap the connection, run the code, and investigate the profiling
+    information. This class is not intended for production use.
+    """
+
+    def __init__(self, conn, profile_dir):
+        self._conn = conn
+        self._profile_dir = Path(profile_dir).resolve()
+        self._counter = itertools.count(1)
+
+        self._conn.enable_profiling()
+
+    def sql(self, *args, **kwargs):
+        # Instances of DuckDBPyRelation, which are returned by DuckDBPyConnection.sql,
+        # are lazy. We have to execute them here to get the profiling information now.
+        rel = self._conn.sql(*args, **kwargs).execute()
+        info = self._conn.get_profiling_information()
+        f_out = self._profile_dir / f"query_{next(self._counter):03d}.json"
+        f_out.write_text(info)
+        return rel
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)

--- a/tests/data/utils/test_duckdb_utils.py
+++ b/tests/data/utils/test_duckdb_utils.py
@@ -1,0 +1,15 @@
+import json
+
+import duckdb
+
+from openprescribing.data.utils.duckdb_utils import ProfilingConnection
+
+
+def test_profiling_connection(tmp_path):
+    conn = ProfilingConnection(duckdb.connect(), tmp_path)
+    conn.sql("SELECT 1")
+    conn.sql("SELECT 2")
+    conn.close()
+    q1, q2 = [json.loads(q.read_text()) for q in tmp_path.iterdir()]
+    assert q1["query_name"] == "SELECT 1"
+    assert q2["query_name"] == "SELECT 2"


### PR DESCRIPTION
This class writes profiling information to a JSON file each time the `.sql` method is called. The profiling information can, for example, help us identify the queries that use the most memory. It looks something like this:

```json
{
    "total_memory_allocated": 0,
    "total_bytes_written": 0,
    "total_bytes_read": 0,
    "system_peak_temp_dir_size": 0,
    "system_peak_buffer_memory": 0,
    "rows_returned": 1,
    "result_set_size": 4,
    "latency": 0.000677621,
    "wal_replay_entry_count": 0,
    "extra_info": {},
    "commit_local_storage_latency": 0.0,
    "attach_load_storage_latency": 0.0,
    "query_name": "SELECT 1",
    "cpu_time": 0.000028329,
    "checkpoint_latency": 0.0,
    "cumulative_cardinality": 2,
    "waiting_to_attach_latency": 0.0,
    "write_to_wal_latency": 0.0,
    "attach_replay_wal_latency": 0.0,
    "blocked_thread_time": 0.0,
    "cumulative_rows_scanned": 0,
    "children": [
        {
          ...
        }
    ]
}
```