### PR TITLE
Correctly handle case where AMP matches baseline filter but VMP doesn't

### DIFF
--- a/openprescribing/web/static/js/build-analysis.js
+++ b/openprescribing/web/static/js/build-analysis.js
@@ -31,7 +31,7 @@
 //
 // Evaluating the filters gives each medication one of three statuses:
 //
-//  - INCLUDED: matches all inclusion filters
+//  - INCLUDED: matches all inclusion filters and no exclusion filter
 //  - EXCLUDED: matches at least one exclusion filter
 //  - NOT_INCLUDED: does not match all inclusion filters
 //

--- a/openprescribing/web/static/js/build-analysis.js
+++ b/openprescribing/web/static/js/build-analysis.js
@@ -1,3 +1,91 @@
+// Analysis builder
+// =================
+//
+// This is the entry point for the "build an analysis" page.  It lets a user describe a
+// set of medications by combining filters, shows which medications match, and builds a
+// shareable URL that drives the resulting prescribing analysis.
+//
+// Panels
+// ------
+// The page has two independent query panels (for the numerator and denominator queries
+// of an analysis).  Each panel has its own filters, its own results, and its own slice
+// of the URL parameters (namespaced by a per-panel prefix).  Everything below applies
+// to a single panel.
+//
+// Filters
+// -------
+// The available filters are defined in filters.js.  To build a medications query, users
+// can add filter controls, to either include or exclude medications that match the
+// filter.  Users can select one or more items from a filter control.
+//
+// Queries
+// ------
+//
+// A query is made up of one or more filters, and returns a collection of medications
+// that match the filters, according to these rules:
+//
+//  - a medication matches a filter if it matches any of the items from the filter
+//  - a medication is *excluded* if it matches any exclusion filter
+//  - otherwise a medication is *included* only if it matches every active inclusion
+//    filter
+//
+// Evaluating the filters gives each medication one of three statuses:
+//
+//  - INCLUDED: matches all inclusion filters
+//  - EXCLUDED: matches at least one exclusion filter
+//  - NOT_INCLUDED: does not match all inclusion filters
+//
+// A fourth status, VMP_NOT_INCLUDED_BUT_CHILD_AMP_IS, is then derived for any
+// not-included VMP that has an included AMP child (see the subtlety under Results).
+//
+// Baseline filters and visibility
+// -------------------------------
+// Some filters are "baseline" filters: they additionally determine which medications
+// are visible in the results.  Currently, only form/route is not a baseline filter.
+// This allows users to filter the results progressively, by adding one filter at a
+// time, while still being able to see medications that match all other filters.
+//
+// As/when we add new filters, we'll have to decide whether they should be baseline
+// filters or not.  A possible rule of thumb: if a filter would match many medications,
+// most of which a user wouldn't want to include in their results, then the filter
+// should not be a baseline filter.
+//
+// Results
+// -------
+// Results are shown as a tree of VTM > VMP > AMP, with a count of the included VMPs and
+// AMPs above it.  Each row is styled by its status:
+//
+//  - INCLUDED: shown normally
+//  - EXCLUDED: greyed out and struck through
+//  - NOT_INCLUDED: greyed out
+//
+// A "show only matching" toggle hides everything except included rows.  Until at least
+// one inclusion filter is added, the panel shows a prompt instead of results.
+//
+// One subtlety: a VMP can sit in a different BNF chapter from its AMPs (eg Amantadine
+// capsules is classified under Parkinson's but has an antiviral AMP).  When a baseline
+// filter keeps an AMP but drops its parent VMP, the VMP is still shown for context,
+// greyed out and expanded so the matching AMP is visible.
+//
+// Dropdowns
+// ---------
+// As filters change, each dropdown only offers values that could still match something
+// given the other active filters, so the user can't accidentally build an empty query.
+//
+// URL state
+// ---------
+// All filter state lives in the URL, so a query is shareable and survives a reload.
+// The page reads its initial state from the URL, writes back on every change, and the
+// summary tab's submit button points at the analysis page for the current state.
+//
+// Module layout
+// -------------
+//   - filters.js   filter definitions and value matching
+//   - metadata.js  fetches medication/dm+d/BNF metadata and builds lookup maps
+//   - query.js     applies filters to produce statuses, counts and dropdown options
+//   - render.js    renders the results tree, filter summary and dropdown options
+//   - dropdown.js  the reusable multi-select dropdown control
+
 import {
   applyFiltersToUrlParams,
   FILTER_DEFINITIONS,

--- a/openprescribing/web/static/js/build-analysis/metadata.js
+++ b/openprescribing/web/static/js/build-analysis/metadata.js
@@ -36,6 +36,9 @@ export async function fetchMetadata(containerEl) {
     medicationIndexesByFilterValue,
     vtmById: new Map(dmd.vtm.map((vtm) => [vtm.id, vtm])),
     vmpById: new Map(dmd.vmp.map((vmp) => [vmp.id, vmp])),
+    medicationById: new Map(
+      indexedMedications.map((medication) => [medication.id, medication]),
+    ),
   };
 }
 

--- a/openprescribing/web/static/js/build-analysis/metadata.js
+++ b/openprescribing/web/static/js/build-analysis/metadata.js
@@ -20,6 +20,7 @@ export async function fetchMetadata(containerEl) {
   const indexedMedications = medications.medications.map(
     (medication, index) => ({
       ...medication,
+      is_vmp: !medication.is_amp,
       medicationIndex: index,
     }),
   );

--- a/openprescribing/web/static/js/build-analysis/query.js
+++ b/openprescribing/web/static/js/build-analysis/query.js
@@ -18,18 +18,22 @@ export const STATUS = {
   EXCLUDED: "excluded",
   // Medication does not match all inclusion filters.
   NOT_INCLUDED: "not_included",
+  // VMP is NOT_INCLUDED, but has an included AMP child.
+  VMP_NOT_INCLUDED_BUT_CHILD_AMP_IS: "vmp_not_included_but_child_amp_is",
 };
 
 export function queryMedications(metadata, filters) {
   // Return visible medications with status, as well as counts of included medications.
-  const baselineMedications = metadata.medications
-    .filter((medication) => matchesBaselineFilters(medication, filters))
-    .map((medication) => ({
-      ...medication,
-      status: getMedicationStatus(medication, filters),
-    }));
-  const medications = baselineMedications.concat(
-    getExcludedParentVmps(baselineMedications, metadata),
+  const baselineMedications = metadata.medications.filter((medication) =>
+    matchesBaselineFilters(medication, filters),
+  );
+  const medications = withVmpChildStatuses(
+    baselineMedications
+      .concat(getExcludedParentVmps(baselineMedications, metadata))
+      .map((medication) => ({
+        ...medication,
+        status: getMedicationStatus(medication, filters),
+      })),
   );
   const includedMedications = medications.filter(
     (medication) => medication.status === STATUS.INCLUDED,
@@ -65,10 +69,37 @@ function getExcludedParentVmps(visibleMedications, metadata) {
     }
   });
 
-  return Array.from(excludedVmpIds, (vmpId) => ({
-    ...metadata.medicationById.get(vmpId),
-    status: STATUS.NOT_INCLUDED,
-  }));
+  return Array.from(excludedVmpIds, (vmpId) =>
+    metadata.medicationById.get(vmpId),
+  );
+}
+
+function withVmpChildStatuses(medications) {
+  // Update the status of each not-included VMP with an included AMP child to
+  // VMP_NOT_INCLUDED_BUT_CHILD_AMP_IS.
+  const vmpIdsWithIncludedAmp = new Set(
+    medications
+      .filter(
+        (medication) =>
+          medication.is_amp && medication.status === STATUS.INCLUDED,
+      )
+      .map((medication) => medication.vmp_id),
+  );
+
+  return medications.map((medication) => {
+    if (
+      !medication.is_amp &&
+      medication.status === STATUS.NOT_INCLUDED &&
+      vmpIdsWithIncludedAmp.has(medication.id)
+    ) {
+      return {
+        ...medication,
+        status: STATUS.VMP_NOT_INCLUDED_BUT_CHILD_AMP_IS,
+      };
+    }
+
+    return medication;
+  });
 }
 
 export function getCachedValidOptionIds(panel, filterKey) {

--- a/openprescribing/web/static/js/build-analysis/query.js
+++ b/openprescribing/web/static/js/build-analysis/query.js
@@ -12,7 +12,7 @@ import {
 } from "./filters.js";
 
 export const STATUS = {
-  // Medication matches all inclusion filters.
+  // Medication matches all inclusion filters and no exclusion filter.
   INCLUDED: "included",
   // Medication matches at least one exclusion filter.
   EXCLUDED: "excluded",
@@ -139,7 +139,8 @@ function matchesVisibleFilters(medication, filters) {
 }
 
 function matchesBaselineFilters(medication, filters) {
-  // Return whether a medication is in the visible baseline set.
+  // Return whether a medication is in the visible baseline set.  If no baseline filters
+  // returns whether it matches any of the other filters.
   const activeBaselineDefinitions = FILTER_DEFINITIONS.filter(
     (definition) =>
       definition.isBaseline &&
@@ -169,29 +170,34 @@ function matchesBaselineFilters(medication, filters) {
 
 function getMedicationStatus(medication, filters) {
   // Return the display status for a medication.
-  for (const definition of FILTER_DEFINITIONS) {
-    const excludedValues = filters[getFilterControlKey(definition, true)];
 
-    if (
-      excludedValues.length > 0 &&
-      matchesAnyFilterValue(definition, medication, excludedValues)
-    ) {
-      return STATUS.EXCLUDED;
-    }
-  }
-
-  for (const definition of FILTER_DEFINITIONS) {
+  const matchesAllInclusionFilters = FILTER_DEFINITIONS.every((definition) => {
     const includedValues = filters[getFilterControlKey(definition, false)];
 
-    if (
-      includedValues.length > 0 &&
-      !matchesAnyFilterValue(definition, medication, includedValues)
-    ) {
-      return STATUS.NOT_INCLUDED;
-    }
+    return (
+      includedValues.length === 0 ||
+      matchesAnyFilterValue(definition, medication, includedValues)
+    );
+  });
+
+  const matchesAnyExclusionFilter = FILTER_DEFINITIONS.some((definition) => {
+    const excludedValues = filters[getFilterControlKey(definition, true)];
+
+    return (
+      excludedValues.length > 0 &&
+      matchesAnyFilterValue(definition, medication, excludedValues)
+    );
+  });
+
+  if (matchesAllInclusionFilters && !matchesAnyExclusionFilter) {
+    return STATUS.INCLUDED;
   }
 
-  return STATUS.INCLUDED;
+  if (matchesAnyExclusionFilter) {
+    return STATUS.EXCLUDED;
+  }
+
+  return STATUS.NOT_INCLUDED;
 }
 
 function getValidOptionIds(filterKey, metadata, filters) {

--- a/openprescribing/web/static/js/build-analysis/query.js
+++ b/openprescribing/web/static/js/build-analysis/query.js
@@ -39,7 +39,7 @@ export function queryMedications(metadata, filters) {
     (medication) => medication.status === STATUS.INCLUDED,
   );
   const includedVmpCount = includedMedications.filter(
-    (medication) => !medication.is_amp,
+    (medication) => medication.is_vmp,
   ).length;
   const includedAmpCount = includedMedications.filter(
     (medication) => medication.is_amp,
@@ -58,7 +58,7 @@ function getExcludedParentVmps(visibleMedications, metadata) {
   // baseline filters.
   const visibleVmpIds = new Set(
     visibleMedications
-      .filter((medication) => !medication.is_amp)
+      .filter((medication) => medication.is_vmp)
       .map((medication) => medication.id),
   );
 
@@ -88,7 +88,7 @@ function withVmpChildStatuses(medications) {
 
   return medications.map((medication) => {
     if (
-      !medication.is_amp &&
+      medication.is_vmp &&
       medication.status === STATUS.NOT_INCLUDED &&
       vmpIdsWithIncludedAmp.has(medication.id)
     ) {

--- a/openprescribing/web/static/js/build-analysis/query.js
+++ b/openprescribing/web/static/js/build-analysis/query.js
@@ -22,12 +22,15 @@ export const STATUS = {
 
 export function queryMedications(metadata, filters) {
   // Return visible medications with status, as well as counts of included medications.
-  const medications = metadata.medications
+  const baselineMedications = metadata.medications
     .filter((medication) => matchesBaselineFilters(medication, filters))
     .map((medication) => ({
       ...medication,
       status: getMedicationStatus(medication, filters),
     }));
+  const medications = baselineMedications.concat(
+    getExcludedParentVmps(baselineMedications, metadata),
+  );
   const includedMedications = medications.filter(
     (medication) => medication.status === STATUS.INCLUDED,
   );
@@ -44,6 +47,28 @@ export function queryMedications(metadata, filters) {
     includedVmpCount,
     includedAmpCount,
   };
+}
+
+function getExcludedParentVmps(visibleMedications, metadata) {
+  // Return the parent VMPs of any visible AMP whose own VMP record was excluded by the
+  // baseline filters.
+  const visibleVmpIds = new Set(
+    visibleMedications
+      .filter((medication) => !medication.is_amp)
+      .map((medication) => medication.id),
+  );
+
+  const excludedVmpIds = new Set();
+  visibleMedications.forEach((medication) => {
+    if (medication.is_amp && !visibleVmpIds.has(medication.vmp_id)) {
+      excludedVmpIds.add(medication.vmp_id);
+    }
+  });
+
+  return Array.from(excludedVmpIds, (vmpId) => ({
+    ...metadata.medicationById.get(vmpId),
+    status: STATUS.NOT_INCLUDED,
+  }));
 }
 
 export function getCachedValidOptionIds(panel, filterKey) {

--- a/openprescribing/web/static/js/build-analysis/render.js
+++ b/openprescribing/web/static/js/build-analysis/render.js
@@ -145,7 +145,9 @@ function getMedicationsToRender(panel, medications) {
   }
 
   return medications.filter(
-    (medication) => medication.status === STATUS.INCLUDED,
+    (medication) =>
+      medication.status === STATUS.INCLUDED ||
+      medication.status === STATUS.VMP_NOT_INCLUDED_BUT_CHILD_AMP_IS,
   );
 }
 
@@ -203,6 +205,8 @@ function groupResults(results, metadata) {
 
     vtmGroup.vmps.forEach((vmpGroup) => {
       sortByName(vmpGroup.amps);
+      vmpGroup.expanded =
+        vmpGroup.status === STATUS.VMP_NOT_INCLUDED_BUT_CHILD_AMP_IS;
     });
 
     vtmGroup.status = getGroupStatus(vtmGroup.vmps.map((vmp) => vmp.status));
@@ -242,7 +246,7 @@ function renderResultsTable(panel, groups, templates) {
       rows.appendChild(makeVmpRow(vmp, templates.vmpRowTemplate));
 
       vmp.amps.forEach((amp) => {
-        rows.appendChild(makeAmpRow(amp, vmp.id, templates.ampRowTemplate));
+        rows.appendChild(makeAmpRow(amp, vmp, templates.ampRowTemplate));
       });
     });
   });
@@ -270,15 +274,21 @@ function makeVmpRow(vmp, template) {
   if (vmp.amps.length > 0) {
     toggleButton.style.visibility = "visible";
     toggleButton.dataset.vmpId = String(vmp.id);
+
+    if (vmp.expanded) {
+      toggleButton.dataset.expanded = "true";
+      toggleButton.querySelector("i").className = "bi bi-caret-down-fill";
+    }
   }
 
   return row;
 }
 
-function makeAmpRow(amp, vmpId, template) {
+function makeAmpRow(amp, vmp, template) {
   // Build an AMP table row.
   const row = cloneRow(template);
-  row.dataset.ampRow = String(vmpId);
+  row.dataset.ampRow = String(vmp.id);
+  row.hidden = !vmp.expanded;
   applyStatusStyling(row, amp.status);
   row.querySelector("[data-name]").textContent = amp.name;
   row.querySelector("[data-form-route]").textContent = amp.formRouteText;

--- a/tests/js/build-analysis/query.test.js
+++ b/tests/js/build-analysis/query.test.js
@@ -196,8 +196,14 @@ describe("queryMedications with excluded parent VMPs", () => {
   });
 });
 
-function makeMetadata(medications) {
+function makeMetadata(rawMedications) {
   // Build the subset of the metadata object that queryMedications relies on.
+  // Derive is_vmp the same way metadata.js does for medications from the API.
+  const medications = rawMedications.map((medication) => ({
+    ...medication,
+    is_vmp: !medication.is_amp,
+  }));
+
   return {
     medications,
     medicationById: new Map(

--- a/tests/js/build-analysis/query.test.js
+++ b/tests/js/build-analysis/query.test.js
@@ -1,0 +1,231 @@
+import {
+  getEmptyFilters,
+  getFilterControlKey,
+} from "@js/build-analysis/filters.js";
+import { queryMedications, STATUS } from "@js/build-analysis/query.js";
+import { describe, expect, it } from "vitest";
+
+// A small world of three VMPs, each with one AMP child, spanning two VTMs, three
+// ingredients, BNF chapters 04-06, and three form/routes.
+//
+// VMP3 shares VTM 10 with VMP1 but sits in chapter 05, so it can match one baseline
+// filter without matching another. Its AMP child (AMP3) sits in chapter 06 -- a
+// different chapter from its parent -- so a chapter 06 filter drops VMP3 while keeping
+// AMP3 (the excluded-parent-VMP case).  See #410 for more context.
+const VMP1 = {
+  id: 1,
+  name: "VMP1",
+  is_amp: false,
+  vmp_id: 1,
+  vtm_id: 10,
+  bnf_code: "0401000A0AAAAAA",
+  form_routes: ["tablet.oral"],
+  ingredient_ids: [100],
+};
+const AMP1 = {
+  id: 2,
+  name: "AMP1",
+  is_amp: true,
+  vmp_id: 1,
+  vtm_id: 10,
+  bnf_code: "0401000A0AAAAAA",
+  form_routes: ["tablet.oral"],
+  ingredient_ids: [100],
+};
+const VMP2 = {
+  id: 3,
+  name: "VMP2",
+  is_amp: false,
+  vmp_id: 3,
+  vtm_id: 20,
+  bnf_code: "0501000B0AAAAAA",
+  form_routes: ["capsule.oral"],
+  ingredient_ids: [200],
+};
+const AMP2 = {
+  id: 4,
+  name: "AMP2",
+  is_amp: true,
+  vmp_id: 3,
+  vtm_id: 20,
+  bnf_code: "0501000B0AAAAAA",
+  form_routes: ["capsule.oral"],
+  ingredient_ids: [200],
+};
+const VMP3 = {
+  id: 5,
+  name: "VMP3",
+  is_amp: false,
+  vmp_id: 5,
+  vtm_id: 10,
+  bnf_code: "0502000C0AAAAAA",
+  form_routes: ["solution.oral"],
+  ingredient_ids: [300],
+};
+const AMP3 = {
+  id: 6,
+  name: "AMP3",
+  is_amp: true,
+  vmp_id: 5,
+  vtm_id: 10,
+  bnf_code: "0601000D0AAAAAA",  // note a different BNF code to VMP3
+  form_routes: ["solution.oral"],
+  ingredient_ids: [300],
+};
+
+const METADATA = makeMetadata([VMP1, AMP1, VMP2, AMP2, VMP3, AMP3]);
+
+describe("queryMedications", () => {
+  it("drops medications outside a single baseline inclusion filter", () => {
+    const result = queryMedications(
+      METADATA,
+      makeFilters({ [include("bnfCodePrefix")]: ["04"] }),
+    );
+    expectMedications(result, [
+      [VMP1, STATUS.INCLUDED],
+      [AMP1, STATUS.INCLUDED],
+    ]);
+    expect(result.includedCount).toBe(2);
+    expect(result.includedVmpCount).toBe(1);
+    expect(result.includedAmpCount).toBe(1);
+  });
+
+  it("ORs the values within a single filter control", () => {
+    const result = queryMedications(
+      METADATA,
+      makeFilters({ [include("bnfCodePrefix")]: ["0401", "0501"] }),
+    );
+    expectMedications(result, [
+      [VMP1, STATUS.INCLUDED],
+      [AMP1, STATUS.INCLUDED],
+      [VMP2, STATUS.INCLUDED],
+      [AMP2, STATUS.INCLUDED],
+    ]);
+    expect(result.includedCount).toBe(4);
+    expect(result.includedVmpCount).toBe(2);
+    expect(result.includedAmpCount).toBe(2);
+  });
+
+  it("ANDs the values between filter controls", () => {
+    const result = queryMedications(
+      METADATA,
+      makeFilters({ [include("vtmId")]: [10], [include("bnfCodePrefix")]: ["04"] }),
+    );
+    expectMedications(result, [
+      [VMP1, STATUS.INCLUDED],
+      [AMP1, STATUS.INCLUDED],
+      [VMP3, STATUS.NOT_INCLUDED],
+      [AMP3, STATUS.NOT_INCLUDED],
+    ]);
+    expect(result.includedCount).toBe(2);
+    expect(result.includedVmpCount).toBe(1);
+    expect(result.includedAmpCount).toBe(1);
+  });
+
+  it("marks medications matching an exclusion filter as excluded and omits them from the count", () => {
+    const result = queryMedications(
+      METADATA,
+      makeFilters({
+        [include("bnfCodePrefix")]: ["05"],
+        [exclude("formRouteId")]: ["capsule.oral"],
+      }),
+    );
+    expectMedications(result, [
+      [VMP2, STATUS.EXCLUDED],
+      [AMP2, STATUS.EXCLUDED],
+      [VMP3, STATUS.INCLUDED],
+    ]);
+    expect(result.includedCount).toBe(1);
+    expect(result.includedVmpCount).toBe(1);
+    expect(result.includedAmpCount).toBe(0);
+  });
+
+  it("prefers excluded over not-included when both apply", () => {
+    const result = queryMedications(
+      METADATA,
+      makeFilters({
+        [include("vtmId")]: [10],
+        [include("ingredientId")]: [100],
+        [exclude("formRouteId")]: ["solution.oral"],
+      }),
+    );
+
+    expectMedications(result, [
+      [VMP1, STATUS.INCLUDED],
+      [AMP1, STATUS.INCLUDED],
+      [VMP3, STATUS.EXCLUDED],
+      [AMP3, STATUS.EXCLUDED],
+    ]);
+    expect(result.includedCount).toBe(2);
+    expect(result.includedVmpCount).toBe(1);
+    expect(result.includedAmpCount).toBe(1);
+  });
+});
+
+describe("queryMedications with excluded parent VMPs", () => {
+  // These exercise VMP3, whose AMP child sits in a different BNF chapter, so a chapter
+  // 06 filter drops VMP3 itself while keeping AMP3.
+
+  it("retains a parent VMP excluded by a baseline filter when one of its AMPs matches", () => {
+    const result = queryMedications(
+      METADATA,
+      makeFilters({ [include("bnfCodePrefix")]: ["06"] }),
+    );
+    expectMedications(result, [
+      [VMP3, STATUS.VMP_NOT_INCLUDED_BUT_CHILD_AMP_IS],
+      [AMP3, STATUS.INCLUDED],
+    ]);
+    expect(result.includedCount).toBe(1);
+    expect(result.includedVmpCount).toBe(0);
+    expect(result.includedAmpCount).toBe(1);
+  });
+
+  it("retains a parent VMP when it matches a non-baseline filter", () => {
+    const result = queryMedications(
+      METADATA,
+      makeFilters({
+        [include("bnfCodePrefix")]: ["06"],
+        [include("formRouteId")]: ["solution.oral"],
+      }),
+    );
+    expectMedications(result, [
+      [VMP3, STATUS.VMP_NOT_INCLUDED_BUT_CHILD_AMP_IS],
+      [AMP3, STATUS.INCLUDED],
+    ]);
+    expect(result.includedVmpCount).toBe(0);
+  });
+});
+
+function makeMetadata(medications) {
+  // Build the subset of the metadata object that queryMedications relies on.
+  return {
+    medications,
+    medicationById: new Map(
+      medications.map((medication) => [medication.id, medication]),
+    ),
+  };
+}
+
+function makeFilters(overrides) {
+  return { ...getEmptyFilters(), ...overrides };
+}
+
+function include(key) {
+  return getFilterControlKey({ key }, false);
+}
+function exclude(key) {
+  return getFilterControlKey({ key }, true);
+}
+
+function expectMedications(result, expectedStatuses) {
+  // Assert exactly which medications are in the results, and the status of each.
+  const actualStatusById = new Map(
+    result.medications.map((medication) => [medication.id, medication.status]),
+  );
+  const expectedStatusById = new Map(
+    expectedStatuses.map(([medication, status]) => [medication.id, status]),
+  );
+
+  expect(actualStatusById).toEqual(expectedStatusById);
+  expect(result.medications).toHaveLength(expectedStatuses.length);
+}


### PR DESCRIPTION
This PR addresses #410, as well as adding some unit tests for code that is only covered by functional tests, and a comment explaining explaining how the analysis builder JS works.

Fixes #410.