### PR TITLE
Add an index date for analyses

### DIFF
--- a/openprescribing/data/ingestors/prescribing.py
+++ b/openprescribing/data/ingestors/prescribing.py
@@ -308,7 +308,8 @@ def ingest_sources(conn):
         COALESCE(bnf_code_changes_source.new_code, presentation.bnf_code) AS bnf_code,
         presentation.bnf_code AS original_bnf_code,
         COALESCE(vmp_code_changes_source.new_vpid, presentation.snomed_code) AS snomed_code,
-        presentation.snomed_code AS original_snomed_code
+        presentation.snomed_code AS original_snomed_code,
+        presentation.last_prescribed_date
     FROM presentation
     LEFT JOIN bnf_code_changes_source
         ON presentation.bnf_code = bnf_code_changes_source.old_code
@@ -401,9 +402,10 @@ def sql_for_presentation_table():
             AS INT4)
         AS id,
         bnf_code,
-        snomed_code
+        snomed_code,
+        last_prescribed_date
     FROM (
-        SELECT DISTINCT bnf_code, snomed_code FROM prescribing_source
+        SELECT bnf_code, snomed_code, MAX(date) AS last_prescribed_date FROM prescribing_source GROUP BY bnf_code, snomed_code
     )
     """
 

--- a/openprescribing/web/api.py
+++ b/openprescribing/web/api.py
@@ -18,20 +18,27 @@ from openprescribing.web.decorators import add_cache_headers, cache
 # allow this to be configured by the user, or calculated directly from the data.
 DATE_COUNT = 96
 
+# This is the first month that we have monthly list size updates for.
+INDEX_DATE = "2017-04-01"
+
 # The number of individual medications shown as their own band in the "by medication"
 # stacked area chart.  Any further medications are summed into a single "Other" band.
 MEDICATIONS_TOP_N = 10
 
+PRESENTATIONS_PRESCRIBED_AFTER_INDEX_DATE_SQL = f"""
+    SELECT bnf_code FROM presentation WHERE last_prescribed_date > '{INDEX_DATE}'
+"""
+
 # Selects medications that have been prescribed: VMPs/AMPs whose BNF code appears in the
 # prescribing data, plus the parent VMPs of any prescribed AMPs.
-PRESCRIBED_MEDICATIONS_SQL = """
+PRESCRIBED_MEDICATIONS_SQL = f"""
     SELECT * FROM medications
-    WHERE bnf_code IN (SELECT bnf_code FROM presentation)
+    WHERE bnf_code IN ({PRESENTATIONS_PRESCRIBED_AFTER_INDEX_DATE_SQL})
     OR (
         NOT is_amp
         AND id IN (
             SELECT DISTINCT vmp_id FROM medications
-            WHERE is_amp AND bnf_code IN (SELECT bnf_code FROM presentation)
+            WHERE is_amp AND bnf_code IN ({PRESENTATIONS_PRESCRIBED_AFTER_INDEX_DATE_SQL})
         )
     )
 """

--- a/tests/data/ingestors/test_prescribing.py
+++ b/tests/data/ingestors/test_prescribing.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 
 import duckdb
 import pytest
@@ -127,6 +128,7 @@ def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings, data_db
             "original_bnf_code": "01234ABC",
             "snomed_code": 87654321,
             "original_snomed_code": 87654321,
+            "last_prescribed_date": datetime.date(2025, 1, 1),
         },
         {
             "id": 2,
@@ -134,6 +136,7 @@ def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings, data_db
             "original_bnf_code": "NEW12345",
             "snomed_code": 12345678,
             "original_snomed_code": 12345678,
+            "last_prescribed_date": datetime.date(2024, 1, 1),
         },
         {
             "id": 3,
@@ -141,6 +144,7 @@ def test_prescribing_ingest_applies_bnf_code_changes(tmp_path, settings, data_db
             "original_bnf_code": "OLD12345",
             "snomed_code": 12345678,
             "original_snomed_code": 12345678,
+            "last_prescribed_date": datetime.date(2023, 1, 1),
         },
     ]
 
@@ -231,6 +235,7 @@ def test_prescribing_ingest_applies_vmp_code_changes(
             "original_bnf_code": "01234ABC",
             "snomed_code": 3000,
             "original_snomed_code": 1000,
+            "last_prescribed_date": datetime.date(2023, 1, 1),
         },
         {
             "id": 2,
@@ -238,6 +243,7 @@ def test_prescribing_ingest_applies_vmp_code_changes(
             "original_bnf_code": "01234ABC",
             "snomed_code": 3000,
             "original_snomed_code": 2000,
+            "last_prescribed_date": datetime.date(2024, 1, 1),
         },
         {
             "id": 3,
@@ -245,6 +251,7 @@ def test_prescribing_ingest_applies_vmp_code_changes(
             "original_bnf_code": "01234ABC",
             "snomed_code": 3000,
             "original_snomed_code": 3000,
+            "last_prescribed_date": datetime.date(2025, 1, 1),
         },
     ]
 

--- a/tests/utils/data_utils.py
+++ b/tests/utils/data_utils.py
@@ -1,6 +1,8 @@
 import datetime
+from enum import Enum
 
 from openprescribing.data.models import BNFCode, Org, OrgRelation
+from openprescribing.web.api import INDEX_DATE
 
 
 def generate_test_data(rxdb, bnf_codes):
@@ -60,3 +62,17 @@ def generate_test_data(rxdb, bnf_codes):
     )
 
     return {"list_size_data": list_size_data, "prescribing_data": prescribing_data}
+
+
+class DateRelativeToIndexDate(Enum):
+    BEFORE = 1
+    AFTER = 2
+
+
+def default_date_relative_to_index_date(relation_to_index_date):
+    if relation_to_index_date == DateRelativeToIndexDate.BEFORE:
+        prescribing_datetime_delta = datetime.timedelta(weeks=-2)
+    else:
+        prescribing_datetime_delta = datetime.timedelta(weeks=2)
+
+    return str(datetime.date.fromisoformat(INDEX_DATE) + prescribing_datetime_delta)

--- a/tests/utils/rxdb_utils.py
+++ b/tests/utils/rxdb_utils.py
@@ -14,6 +14,10 @@ from openprescribing.data.rxdb.connection import (
     CursorCacheKeyWrapper,
 )
 from openprescribing.data.utils.duckdb_utils import escape
+from tests.utils.data_utils import (
+    DateRelativeToIndexDate,
+    default_date_relative_to_index_date,
+)
 
 
 PRESCRIBING_SOURCE_SCHEMA = pyarrow.schema(
@@ -33,7 +37,6 @@ PRESCRIBING_SOURCE_SCHEMA = pyarrow.schema(
 PRESCRIBING_SOURCE_DEFAULTS = {
     "bnf_code": "",
     "snomed_code": 0,
-    "date": datetime.date(2000, 1, 1),
     "practice_code": "",
     "quantity_value": 0.0,
     "items": 0,
@@ -125,6 +128,12 @@ def rxdb_ingest(conn, prescribing_data=(), list_size_data=()):
     If tests need to supply their own BNF code changes, we should add a bnf_code_changes
     parameter to this function.
     """
+
+    # Set our default date to be after api's INDEX_DATE
+    PRESCRIBING_SOURCE_DEFAULTS["date"] = default_date_relative_to_index_date(
+        DateRelativeToIndexDate.AFTER
+    )
+
     prescribing_data = prepare_data(prescribing_data, PRESCRIBING_SOURCE_DEFAULTS)
     list_size_data = prepare_data(list_size_data, LIST_SIZE_SOURCE_DEFAULTS)
     prescribing_source = pyarrow.Table.from_pylist(

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -4,6 +4,10 @@ from urllib.parse import urlencode
 import pytest
 
 from openprescribing.web import api
+from tests.utils.data_utils import (
+    DateRelativeToIndexDate,
+    default_date_relative_to_index_date,
+)
 from tests.utils.ingest_utils import ingest_dmd_bnf_map_data, ingest_dmd_data
 
 
@@ -216,12 +220,26 @@ def test_prescribing_medications_groups_other(client, sample_data, monkeypatch):
     assert "Other" in medications
 
 
-def test_metadata_medications(client, rxdb, settings, tmp_path):
-    rxdb.ingest([{"bnf_code": "1106000X0AAA4A4"}])
+@pytest.mark.parametrize(
+    "prescribing_date_relative_to_index_date",
+    [DateRelativeToIndexDate.BEFORE, DateRelativeToIndexDate.AFTER],
+)
+def test_metadata_medications(
+    client, rxdb, settings, tmp_path, prescribing_date_relative_to_index_date
+):
+    prescribing_date = default_date_relative_to_index_date(
+        prescribing_date_relative_to_index_date
+    )
+
+    rxdb.ingest([{"bnf_code": "1106000X0AAA4A4", "date": str(prescribing_date)}])
     ingest_dmd_data(settings, tmp_path)
     ingest_dmd_bnf_map_data(settings, tmp_path)
     rsp = client.get("/api/metadata/medications/")
     payload = rsp.json()
+
+    if prescribing_date_relative_to_index_date == DateRelativeToIndexDate.BEFORE:
+        assert [] == payload["medications"]
+        return
 
     assert {
         "id": 9393711000001102,
@@ -247,7 +265,16 @@ def test_metadata_medications(client, rxdb, settings, tmp_path):
     } in payload["medications"]
 
 
-def test_metadata_dmd(client, rxdb, medications):
+@pytest.mark.parametrize(
+    "prescribing_date_relative_to_index_date",
+    [DateRelativeToIndexDate.BEFORE, DateRelativeToIndexDate.AFTER],
+)
+def test_metadata_dmd(
+    client, rxdb, medications, prescribing_date_relative_to_index_date
+):
+    prescribing_date = default_date_relative_to_index_date(
+        prescribing_date_relative_to_index_date
+    )
     # Two VMPs with distinct VTMs, ingredients and form/routes, plus an AMP belonging to
     # the first VMP; only the first VMP (and hence its AMP) is then prescribed.
     medications.add_rows(
@@ -273,9 +300,14 @@ def test_metadata_dmd(client, rxdb, medications):
             },
         ]
     )
-    rxdb.ingest([{"bnf_code": "1001030U0AAABAB"}])
+    rxdb.ingest([{"bnf_code": "1001030U0AAABAB", "date": prescribing_date}])
 
     payload = client.get("/api/metadata/dmd/").json()
+
+    if prescribing_date_relative_to_index_date == DateRelativeToIndexDate.BEFORE:
+        assert payload["vmp"] == []
+        assert payload["amp"] == []
+        return
 
     # Only the prescribed VMP, its AMP, and the VTM, ingredient and form/route they
     # relate to are returned; the unprescribed VMP's objects are excluded.
@@ -286,15 +318,30 @@ def test_metadata_dmd(client, rxdb, medications):
     assert [record["descr"] for record in payload["ont_form_route"]] == ["tablet.oral"]
 
 
-def test_metadata_bnf(client, rxdb, bnf_codes, medications):
+@pytest.mark.parametrize(
+    "prescribing_date_relative_to_index_date",
+    [DateRelativeToIndexDate.BEFORE, DateRelativeToIndexDate.AFTER],
+)
+def test_metadata_bnf(
+    client, rxdb, bnf_codes, medications, prescribing_date_relative_to_index_date
+):
+    prescribing_date = default_date_relative_to_index_date(
+        prescribing_date_relative_to_index_date
+    )
+
     # The bnf_codes fixture provides the BNF hierarchy; we also need to link a VMP to a
     # generic methotrexate presentation and prescribe it so that appears in the
     # medications view.
     medications.add_rows([{"bnf_code": "1001030U0BDAAAB"}])
-    rxdb.ingest([{"bnf_code": "1001030U0BDAAAB"}])
+    rxdb.ingest([{"bnf_code": "1001030U0BDAAAB", "date": prescribing_date}])
 
     rsp = client.get("/api/metadata/bnf/")
     payload = rsp.json()
+
+    if prescribing_date_relative_to_index_date == DateRelativeToIndexDate.BEFORE:
+        assert payload["bnf"] == []
+        return
+
     assert {
         "code": "10",
         "level": 1,


### PR DESCRIPTION
* This is the date from which we have all the data we need to do an analysis
* We've chosen this date because this is when we start having monthly list size data available
* We could choose different criteria, for example when we start having dm+d codes in prescribing data (which is in 2020), but this will do for now
* Add the latest prescribing date to the presentations table at ingest so that we:
  * don't throw out any data, and can potentially use different index dates for different types of query in future
  * have performant queries
