### PR TITLE
Build DOM nodes directly in JS

### DIFF
--- a/openprescribing/web/static/js/build-analysis.js
+++ b/openprescribing/web/static/js/build-analysis.js
@@ -130,17 +130,8 @@ const summarySectionElsByPrefix = new Map(
 // Templates that we'll use to generate elements in the document.
 const templates = {
   dropdownTemplate: containerEl.querySelector("[data-dropdown-template]"),
-  dropdownOptionTemplate: containerEl.querySelector(
-    "[data-dropdown-option-template]",
-  ),
-  summaryListTemplate: containerEl.querySelector(
-    "[data-summary-list-template]",
-  ),
   summaryListItemTemplate: containerEl.querySelector(
     "[data-summary-list-item-template]",
-  ),
-  summaryEmptyListItemTemplate: containerEl.querySelector(
-    "[data-summary-empty-list-item-template]",
   ),
   vtmRowTemplate: containerEl.querySelector("[data-vtm-row-template]"),
   vmpRowTemplate: containerEl.querySelector("[data-vmp-row-template]"),
@@ -201,7 +192,6 @@ function initialiseQueryPanel(panel) {
   // Wire up the panel.
   panel.dropdowns = new DropdownCollection(panel.refs.filterListEl, {
     template: templates.dropdownTemplate,
-    optionTemplate: templates.dropdownOptionTemplate,
     onChange: () => {
       const filters = getFilters(panel);
       renderAddFilterOptions(panel);

--- a/openprescribing/web/static/js/build-analysis/render.js
+++ b/openprescribing/web/static/js/build-analysis/render.js
@@ -79,12 +79,12 @@ function renderSummarySection(sectionEl, panel, templates) {
     }),
   );
 
-  const listEl = cloneTemplateElement(templates.summaryListTemplate);
+  const listEl = document.createElement("ul");
 
   if (activeFilters.length === 0) {
-    listEl.appendChild(
-      cloneTemplateElement(templates.summaryEmptyListItemTemplate),
-    );
+    const emptyEl = document.createElement("li");
+    emptyEl.textContent = "No filters selected.";
+    listEl.appendChild(emptyEl);
     sectionEl.replaceChildren(listEl);
     return;
   }

--- a/openprescribing/web/static/js/dropdown.js
+++ b/openprescribing/web/static/js/dropdown.js
@@ -3,13 +3,11 @@ export class DropdownCollection {
     el, // container element for all dropdowns
     {
       template, // template for a dropdown control
-      optionTemplate, // template for an option in the open list
       onChange = null, // called whenever selections change or a dropdown is added/removed
     },
   ) {
     this._el = el;
     this._template = template;
-    this._optionTemplate = optionTemplate;
     this._onChange = onChange;
     this._dropdowns = new Map(); // key -> { dropdown, wrapperEl }
   }
@@ -25,7 +23,6 @@ export class DropdownCollection {
     const dropdown = new Dropdown(wrapperEl, {
       ...opts,
       template: this._template,
-      optionTemplate: this._optionTemplate,
       onChange: (selectedIds) => {
         if (userOnChange) userOnChange(selectedIds);
         if (this._onChange) this._onChange(this.getAllSelected());
@@ -89,7 +86,6 @@ class Dropdown {
       options, // all possible options for this dropdown
       getValidOptionIds, // returns the latest precomputed valid IDs when the dropdown opens
       template, // template for the dropdown control
-      optionTemplate, // template for an option in the open list
       selected = [], // initially selected option IDs
       onChange = null, // called whenever the selection changes
       onRemove = null, // called when the remove button is clicked
@@ -102,7 +98,6 @@ class Dropdown {
     this._optionsById = new Map(options.map((o) => [o.id, o]));
     this._getValidOptionIds = getValidOptionIds;
     this._template = template;
-    this._optionTemplate = optionTemplate;
     this._validIds = null;
     this._selected = new Set(selected);
     this._onChange = onChange;
@@ -292,7 +287,7 @@ class Dropdown {
     });
 
     for (const opt of filtered) {
-      const option = cloneTemplateElement(this._optionTemplate);
+      const option = document.createElement("option");
       option.textContent = opt.name;
       option.value = opt.id;
       option.selected = this._selected.has(opt.id);

--- a/openprescribing/web/templates/build_analysis.html
+++ b/openprescribing/web/templates/build_analysis.html
@@ -173,23 +173,11 @@
         </div>
     </template>
 
-    <template data-dropdown-option-template>
-        <option></option>
-    </template>
-
-    <template data-summary-list-template>
-        <ul></ul>
-    </template>
-
     <template data-summary-list-item-template>
         <li>
             <strong data-label></strong>
             <span data-values></span>
         </li>
-    </template>
-
-    <template data-summary-empty-list-item-template>
-        <li>No filters selected.</li>
     </template>
 
 </section>


### PR DESCRIPTION
The templates were for elements carrying no structure, so cloning them via `<template>` gains nothing over `document.createElement`.