### PR TITLE
Add analysis type control to denominator panel

### DIFF
--- a/openprescribing/web/static/js/build-analysis.js
+++ b/openprescribing/web/static/js/build-analysis.js
@@ -126,6 +126,7 @@ const summarySectionElsByPrefix = new Map(
     (element) => [element.dataset.summarySection, element],
   ),
 );
+const dtrFiltersEl = containerEl.querySelector("[data-dtr-filters]");
 
 // Templates that we'll use to generate elements in the document.
 const templates = {
@@ -152,6 +153,7 @@ const initialisePage = async () => {
     });
 
     initialiseQueriesFromUrl(panels);
+    initialiseAnalysisTypeFromUrl();
     refreshSummary(panels);
     loadingEl.hidden = true;
     appEl.hidden = false;
@@ -213,6 +215,13 @@ function initialiseQueryPanel(panel) {
   panel.refs.showOnlyMatchingCheckbox.addEventListener("change", () => {
     handleShowOnlyMatchingChange(panel);
   });
+  panel.root
+    .querySelectorAll("[data-analysis-type-option]")
+    .forEach((input) => {
+      input.addEventListener("change", () => {
+        handleAnalysisTypeChange(panel);
+      });
+    });
 }
 
 function initialiseQueriesFromUrl(panels) {
@@ -226,6 +235,20 @@ function initialiseQueriesFromUrl(panels) {
       runQuery(panel, filters);
     }
   });
+}
+
+function initialiseAnalysisTypeFromUrl() {
+  // Set the analysis type radio button (and denominator filter visibilty) from the URL.
+  const params = new URL(window.location.href).searchParams;
+  const analysisDict = readAnalysisDict(params);
+  if (analysisDict) {
+    const type = analysisDict.options.type;
+    const input = containerEl.querySelector(
+      `[data-analysis-type-option="${type}"]`,
+    );
+    input.checked = true;
+    updateDtrFiltersVisibility();
+  }
 }
 
 function refreshSummary(panels) {
@@ -285,6 +308,13 @@ function handleShowOnlyMatchingChange(panel) {
   if (panel.currentResults) {
     renderResults(panel, panel.currentResults, metadata, templates);
   }
+}
+
+function handleAnalysisTypeChange(panel) {
+  // React to user changing analysis type.
+  updateDtrFiltersVisibility();
+  updateUrlFromFilters(panel, getFilters(panel));
+  refreshSummary([panel]);
 }
 
 function runQuery(panel, filters, updateUrl = false) {
@@ -425,6 +455,7 @@ function updateUrlFromFilters(panel, filters) {
       queryDicts.numerator,
       queryDicts.denominator,
       currentAnalysisDict?.org_id,
+      getSelectedAnalysisType(),
     );
     url.searchParams.set("analysis", JSON.stringify(analysisDict));
   } else {
@@ -434,23 +465,25 @@ function updateUrlFromFilters(panel, filters) {
   window.history.replaceState({}, "", url);
 }
 
+function updateDtrFiltersVisibility() {
+  dtrFiltersEl.hidden =
+    getSelectedAnalysisType() !== "prescribing_vs_prescribing";
+}
+
 function readAnalysisDict(params) {
   // Parse the `analysis` query parameter, returning null when it is absent.
   return JSON.parse(params.get("analysis"));
 }
 
-function buildAnalysisDict(numerator, denominator, orgId) {
+function buildAnalysisDict(numerator, denominator, orgId, type) {
   // Build an analysis dict matching the backend's Analysis.to_dict shape.
   const analysisDict = {
-    options: { output_value: "items" },
+    options: { output_value: "items", type },
     queries: [{ numerator: numerator ?? {} }],
   };
 
-  if (denominator) {
-    analysisDict.queries[0].denominator = denominator;
-    analysisDict.options.type = "prescribing_vs_prescribing";
-  } else {
-    analysisDict.options.type = "prescribing_vs_list_size";
+  if (type === "prescribing_vs_prescribing") {
+    analysisDict.queries[0].denominator = denominator ?? {};
   }
 
   if (orgId) {
@@ -458,6 +491,11 @@ function buildAnalysisDict(numerator, denominator, orgId) {
   }
 
   return analysisDict;
+}
+
+function getSelectedAnalysisType() {
+  // Return the analysis type chosen by the radio button.
+  return containerEl.querySelector("[data-analysis-type-option]:checked").value;
 }
 
 function getQueryDict(analysisDict, prefix) {

--- a/openprescribing/web/static/js/build-analysis.js
+++ b/openprescribing/web/static/js/build-analysis.js
@@ -142,11 +142,14 @@ const templates = {
 // We'll store metadata from the API here.
 let metadata;
 
+// We'll store the query panels here.
+let panels;
+
 const initialisePage = async () => {
   // Load metadata, initialise the query panels, and show the page.
   try {
     metadata = await fetchMetadata(containerEl);
-    const panels = createQueryPanels();
+    panels = createQueryPanels();
 
     panels.forEach((panel) => {
       initialiseQueryPanel(panel);
@@ -154,6 +157,15 @@ const initialisePage = async () => {
 
     initialiseQueriesFromUrl(panels);
     initialiseAnalysisTypeFromUrl();
+    summarySubmitEl.addEventListener("click", (event) => {
+      if (summarySubmitEl.classList.contains("disabled")) {
+        // For a button with Bootstrap's disabled class, the pointer-events property is
+        // set to none, which makes it unclickable.  But it is still possible to select
+        // the element by tabbing to it, and a user could then "press" the button by
+        // hitting enter.
+        event.preventDefault();
+      }
+    });
     refreshSummary(panels);
     loadingEl.hidden = true;
     appEl.hidden = false;
@@ -258,11 +270,34 @@ function refreshSummary(panels) {
 }
 
 function updateSummarySubmitUrl() {
-  // Point the summary submit button at the analysis page for the current filters.
+  // Point the summary submit button at the analysis page for the current filters, and
+  // disable it when the current filters don't describe a valid analysis.
   const url = new URL(containerEl.dataset.analysisUrl, window.location.href);
   url.search = new URL(window.location.href).search;
 
   summarySubmitEl.href = url.toString();
+  summarySubmitEl.classList.toggle("disabled", !isSubmittable());
+}
+
+function isSubmittable() {
+  // An analysis is not submittable if the numerator does not have any filters or
+  // if the analysis type is prescribing_vs_prescribing and the denominator does not
+  // have any selected filters.
+  const ntrPanel = panels.find((panel) => panel.prefix === "ntr");
+  const dtrPanel = panels.find((panel) => panel.prefix === "dtr");
+
+  if (!hasAnyFilters(getFilters(ntrPanel))) {
+    return false;
+  }
+
+  if (
+    getSelectedAnalysisType() === "prescribing_vs_prescribing" &&
+    !hasAnyFilters(getFilters(dtrPanel))
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 function handleAddFilterChange(panel) {

--- a/openprescribing/web/static/js/build-analysis/render.js
+++ b/openprescribing/web/static/js/build-analysis/render.js
@@ -60,6 +60,20 @@ function getActiveFilterControlCount(panel) {
 
 function renderSummarySection(sectionEl, panel, templates) {
   // Render given panel's active filters into its summary section.
+  if (panel.prefix === "dtr") {
+    const analysisType = panel.root.querySelector(
+      "[data-analysis-type-option]:checked",
+    ).value;
+    if (analysisType === "prescribing_vs_list_size") {
+      const listEl = document.createElement("ul");
+      const itemEl = document.createElement("li");
+      itemEl.textContent = "1000 patients";
+      listEl.appendChild(itemEl);
+      sectionEl.replaceChildren(listEl);
+      return;
+    }
+  }
+
   const selectedNamesByKey = panel.dropdowns.getAllSelectedNames();
   const activeFilters = FILTER_DEFINITIONS.flatMap((definition) =>
     [false, true].flatMap((isExcluded) => {

--- a/openprescribing/web/templates/_build_analysis_query_panel.html
+++ b/openprescribing/web/templates/_build_analysis_query_panel.html
@@ -5,7 +5,43 @@
     data-query-panel
     data-panel-prefix="{{ prefix }}"
 >
-    <div class="row g-4">
+    {% if prefix == "dtr" %}
+    <div class="card mb-4">
+        <div class="card-body">
+            <fieldset data-dtr-type>
+                <legend class="h4 card-title">Denominator type</legend>
+                <div class="form-check">
+                    <input
+                        id="dtr-type-list-size"
+                        class="form-check-input"
+                        type="radio"
+                        name="dtr-type"
+                        value="prescribing_vs_list_size"
+                        data-analysis-type-option="prescribing_vs_list_size"
+                        checked
+                    />
+                    <label class="form-check-label" for="dtr-type-list-size">
+                        Per 1,000 patients
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input
+                        id="dtr-type-prescribing"
+                        class="form-check-input"
+                        type="radio"
+                        name="dtr-type"
+                        value="prescribing_vs_prescribing"
+                        data-analysis-type-option="prescribing_vs_prescribing"
+                    />
+                    <label class="form-check-label" for="dtr-type-prescribing">
+                        Prescribing of medications
+                    </label>
+                </div>
+            </fieldset>
+        </div>
+    </div>
+    {% endif %}
+    <div class="row g-4"{% if prefix == "dtr" %} data-dtr-filters hidden{% endif %}>
         <div class="col-md-4">
             <div class="card h-100">
                 <div class="card-body">

--- a/tests/functional/test_build_analysis.py
+++ b/tests/functional/test_build_analysis.py
@@ -206,6 +206,16 @@ def test_build_analyse_has_dynamic_filters_and_independent_queries(
     denominator_tab.click()
     expect(denominator_tab).to_have_attribute("aria-selected", "true")
 
+    # The denominator defaults to per-1,000-patients, with its filters hidden until the
+    # prescribing type is explicitly chosen.
+    expect(
+        analysis_type_option(denominator_panel, "prescribing_vs_list_size")
+    ).to_be_checked()
+    expect(denominator_filters(denominator_panel)).to_be_hidden()
+
+    select_analysis_type(denominator_panel, "prescribing_vs_prescribing")
+    expect(denominator_filters(denominator_panel)).to_be_visible()
+
     add_filter(denominator_panel, "Ingredient")
     select_suggestion(denominator_panel, "Ingredient", "Aden", "Adenosine")
     add_filter(denominator_panel, "Ingredient (excluded)")
@@ -299,6 +309,11 @@ def test_build_analyse_loads_dynamic_filters_from_url(
     expect(results_empty(numerator_panel)).to_be_hidden()
     expect(results_table(numerator_panel)).to_be_visible()
 
+    # Analysis type is restored on the denominator panel from the URL.
+    expect(
+        analysis_type_option(denominator_panel, "prescribing_vs_prescribing")
+    ).to_be_checked()
+
     # Denominator filters are restored independently from the same URL.
     expect(dropdown_rows(denominator_panel)).to_have_count(2)
     assert selected_dropdown_option_labels(denominator_panel, "Ingredient") == [
@@ -314,6 +329,7 @@ def test_build_analyse_loads_dynamic_filters_from_url(
 
     # Switching tabs preserves the restored denominator empty state.
     denominator_tab.click()
+    expect(denominator_filters(denominator_panel)).to_be_visible()
     expect(results_empty(denominator_panel)).to_be_visible()
     expect(results_table(denominator_panel)).to_be_hidden()
 
@@ -338,6 +354,21 @@ def ingest_build_analysis_bnf_data():
         [7, "1106000X0AAA4A4", "Pilocarpine 6% eye drops"],
     ]:
         BNFCode.objects.create(code=code, name=name, level=level)
+
+
+def analysis_type_option(panel, value):
+    """Return the analysis type radio input with the given value."""
+    return panel.locator(f'[data-analysis-type-option="{value}"]')
+
+
+def select_analysis_type(panel, value):
+    """Select the analysis type radio with the given value."""
+    analysis_type_option(panel, value).check()
+
+
+def denominator_filters(panel):
+    """Return the denominator filters/results container."""
+    return panel.locator("[data-dtr-filters]")
 
 
 def add_filter(panel, label):


### PR DESCRIPTION
Previously, if no medications were selected for the numerator, the analysis was inferred to be prescribing_vs_list_size.  There is now a radio control on the denominator tab.  The summary tab also now shows something sensible for prescribing_vs_list_size analyses.

<img width="1345" height="494" alt="image" src="https://github.com/user-attachments/assets/e3a19a0f-eb4c-46fe-8477-08033a93a31a" />
