### PR TITLE
Add a "Save as PNG" button

### DIFF
--- a/openprescribing/web/static/js/prescribing-chart.js
+++ b/openprescribing/web/static/js/prescribing-chart.js
@@ -148,6 +148,12 @@ const embedSpec = async (specName) => {
   chartResult = await vegaEmbed(chartContainer, chartSpecs[specName], {
     renderer: "svg",
   });
+  document.getElementById("png-btn").addEventListener("click", function () {
+    chartResult.view.toImageURL("png", 2).then((url) => {
+      // This "url" is a binary blob containing the image data - ensure it is up to date
+      this.href = url;
+    });
+  });
 };
 
 const updateChart = async (chartConfig) => {

--- a/openprescribing/web/templates/analysis.html
+++ b/openprescribing/web/templates/analysis.html
@@ -114,6 +114,7 @@
                 <section>
                     <a class="btn btn-primary" href="{{ build_analysis_url }}">Edit analysis</a>
                     <a class="btn btn-primary" href="{{ download_analysis_url }}">Download analysis</a>
+                    <a class="btn btn-primary my-1" download="chart.png" href="#" id="png-btn">Save as PNG</a>
                 </section>
             </div>
         </div>

--- a/tests/functional/test_analysis.py
+++ b/tests/functional/test_analysis.py
@@ -58,3 +58,8 @@ def test_analysis(live_server, page, rxdb, settings, tmp_path):
         expect(page.locator(f"#{chart_type}")).to_be_checked()
         expect(page.locator("#chart-container")).to_be_visible()
         expect(page.locator("#chart-container svg.marks")).to_be_visible()
+
+        with page.expect_download() as download:
+            page.get_by_role("link", name="Save as PNG").click()
+        assert download.value.suggested_filename == "chart.png"
+        assert "data:image/png;base64" in download.value.url


### PR DESCRIPTION
* Create a link / button next to the other similar link / buttons
* Use [toImageURL()](https://github.com/vega/vega/blob/main/docs/docs/api/view.md#view_toImageURL), which writes the PNG data directly into the href 
<img width="1262" height="922" alt="Screenshot 2026-07-16 at 16-54-41 OpenPrescribing Beta" src="https://github.com/user-attachments/assets/217d7f0f-4f13-4ab3-bdb7-d9e2262d6085" />
